### PR TITLE
fix: add menu separator before toggle menu item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,347 +2,404 @@
 
 🇬🇧 **English** | 🇯🇵 **日本語**
 
-All notable changes to this project will be documented in this file.  
+All notable changes to this project will be documented in this file.
 このプロジェクトの注目すべき変更はすべてこのファイルに記録されます。
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).  
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 フォーマットは [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) に基づいており、
 このプロジェクトは [Semantic Versioning](https://semver.org/spec/v2.0.0.html) に準拠しています。
 
-## [Unreleased] / [未リリース]
+## [Unreleased]
 
 ## [0.4.1] - 2025-10-19
 
-### Added / 追加
+### Added
 
 - **MA Material Helper: Material Swap Limitation Detection**
-  **MA Material Helper: Material Swap制限の自動検出**
+  - Added automatic detection of Material Swap limitations
+  - Detects when the same material in a mesh needs to be swapped to different materials in different slots
+  - User can choose to continue with Material Swap or cancel to use Material Setter instead
+  - Cancel option uses Undo to cleanly remove all created objects
 
-  - Added automatic detection of Material Swap limitations  
-    Material Swapの制限を自動検出する機能を追加
-  - Detects when the same material in a mesh needs to be swapped to different materials in different slots  
-    同じメッシュ内の同じマテリアルを異なるスロットで別のマテリアルに変更しようとする場合を検出
-  - User can choose to continue with Material Swap or cancel to use Material Setter instead  
-    ユーザーはMaterial Swapを続行するか、キャンセルしてMaterial Setterを使用するか選択可能
-  - Cancel option uses Undo to cleanly remove all created objects  
-    キャンセルした場合はUndoを使用してすべての作成オブジェクトを削除します
+### Fixed
 
-### Fixed / 修正
+- **MA Material Helper: Fixed Parameter Name Conflicts in Multiple Color Menus**
+  - Fixed issue where creating Material Setter/Swap menus on multiple objects would cause parameter conflicts
+    - Now allows independent color changes on multiple objects
+  - Sub-menus within the same Color Menu now share the same parameter
+    - Now allows mixing Material Setter and Material Swap changes simultaneously
+  - When adding to an existing Color Menu, the most commonly used parameter is now reused
 
-- **MA Material Helper: Fixed Parameter Name Conflicts in Multiple Color Menus**  
-  **MA Material Helper: 複数のColor Menuでのパラメーター名競合を修正**
+---
 
-  - Fixed issue where creating Material Setter/Swap menus on multiple objects would cause parameter conflicts  
-    複数のオブジェクトでMaterial Setter/Swapメニューを作成するとパラメーターが競合する問題を修正
-    - Now allows independent color changes on multiple objects  
-      複数のオブジェクトで個別に色変更ができるようになりました
-  - Sub-menus within the same Color Menu now share the same parameter  
-    同じColor Menu内のサブメニューは同じパラメーターを共有するようになりました
-    - Now allows mixing Material Setter and Material Swap changes simultaneously  
-      MaterialSetterとMaterialSwapによる変更を混ぜて同時に利用できるようになりました
-  - When adding to an existing Color Menu, the most commonly used parameter is now reused  
-    既存のColor Menuに追加する場合、もっとも多く使用されているパラメーターを再利用するようになりました
+### 追加
+
+- **MA Material Helper: Material Swap制限の自動検出**
+  - Material Swapの制限を自動検出する機能を追加
+  - 同じメッシュ内の同じマテリアルを異なるスロットで別のマテリアルに変更しようとする場合を検出
+  - ユーザーはMaterial Swapを続行するか、キャンセルしてMaterial Setterを使用するか選択可能
+  - キャンセルした場合はUndoを使用してすべての作成オブジェクトを削除します
+
+### 修正
+
+- **MA Material Helper: 複数のColor Menuでのパラメーター名競合を修正**
+  - 複数のオブジェクトでMaterial Setter/Swapメニューを作成するとパラメーターが競合する問題を修正
+    - 複数のオブジェクトで個別に色変更ができるようになりました
+  - 同じColor Menu内のサブメニューは同じパラメーターを共有するようになりました
+    - MaterialSetterとMaterialSwapによる変更を混ぜて同時に利用できるようになりました
+  - 既存のColor Menuに追加する場合、もっとも多く使用されているパラメーターを再利用するようになりました
 
 ## [0.4.0] - 2025-10-12
 
-### Added / 追加
+### Added
 
 - **AO Bounds Setter: Batch Anchor Override and Bounds Configuration**
-  **AO Bounds Setter: Anchor OverrideとBoundsの一括設定**
+  - Added AO Bounds Setter window for batch configuration of Anchor Override, Root Bone, and Bounds on meshes
+  - Access via `Tools > Kanameliser Editor Plus > AO Bounds Setter`
 
-  - Added AO Bounds Setter window for batch configuration of Anchor Override, Root Bone, and Bounds on meshes  
-    メッシュのAnchor Override、Root Bone、Boundsを一括設定するAO Bounds Setterウィンドウを追加
-  - Access via `Tools > Kanameliser Editor Plus > AO Bounds Setter`  
-    `Tools > Kanameliser Editor Plus > AO Bounds Setter` からアクセス
+- **MA Material Helper: Material Setter Support**
+  - Added Material Setter automatic generation feature alongside existing Material Swap
+  - Allows changing from the same source material to different materials within the same mesh by specifying per-slot
+  - More accurately reproduces the material layout of the source prefab compared to Material Swap
+  - Context menu: `Kanameliser Editor Plus > Create Material Setter`
 
-- **MA Material Helper: Material Setter Support**  
-  **MA Material Helper: Material Setter対応**
-
-  - Added Material Setter automatic generation feature alongside existing Material Swap  
-    既存のMaterial Swapに加えてMaterial Setter自動生成機能を追加
-  - Allows changing from the same source material to different materials within the same mesh by specifying per-slot  
-    スロット単位で指定するため、同じメッシュ内で同一の元マテリアルから異なるマテリアルへの変更が可能
-  - More accurately reproduces the material layout of the source prefab compared to Material Swap  
-    Material Swapより正確にコピー元Prefabのマテリアル配置を再現
-  - Context menu: `Kanameliser Editor Plus > Create Material Setter`  
-    右クリックメニュー：`Kanameliser Editor Plus > Create Material Setter`
-
-- **MA Material Helper: Material Setter All Slots Mode**  
-  **MA Material Helper: Material Setter全スロットモード**
-
-  - Added All Slots mode to Material Setter for cases where all material slots need to be set regardless of changes  
-    変更の有無に関係なく全マテリアルスロットを設定する必要がある場合のために全スロットモードを追加
-  - Standard mode only sets material slots that differ from current materials  
-    標準モードは現在のマテリアルと異なるスロットのみを設定
+- **MA Material Helper: Material Setter All Slots Mode**
+  - Added All Slots mode to Material Setter for cases where all material slots need to be set regardless of changes
+  - Standard mode only sets material slots that differ from current materials
   - Context menu: `[Optional] Create Material Setter (All Slots)`
-    右クリックメニュー：`[Optional] Create Material Setter (All Slots)`
 
-- **MA Material Helper: Material Swap vs Material Setter - Usage Guide**  
-  **MA Material Helper: Material Swap と Material Setter - 使い分けガイド**
+- **MA Material Helper: Material Swap vs Material Setter - Usage Guide**
+  - **Material Setter (Recommended)**:
+    - Sets materials per material slot, ensuring accurate material placement
+    - Handles cases where the same source material maps to different target materials within the same mesh
+    - More reliable for complex prefab structures with mixed materials
+    - **Use Material Setter when in doubt - it works in all scenarios**
+  - **Material Swap (Optional)**:
+    - Swaps materials by material reference, simpler configuration
+    - Suitable when each source material consistently maps to one target material across all meshes
+    - May not work correctly if the same source material needs to map to different targets in different slots
+    - Use `[Optional] Create Material Swap (Per Object)` for more granular control if needed
 
-  - **Material Setter (Recommended / 推奨)**:
-    - Sets materials per material slot, ensuring accurate material placement  
-      マテリアルスロット単位で設定するため、正確なマテリアル配置を保証
-    - Handles cases where the same source material maps to different target materials within the same mesh  
-      同じメッシュ内で同一の元マテリアルが異なるターゲットマテリアルに対応するケースに対応
-    - More reliable for complex prefab structures with mixed materials  
-      混合マテリアルを含む複雑なPrefab構造でより信頼性が高い
-    - **Use Material Setter when in doubt - it works in all scenarios**  
-      **迷ったら Material Setter を使用してください - すべてのシナリオで動作します**
+### Improved
 
-  - **Material Swap (Optional / オプション)**:
-    - Swaps materials by material reference, simpler configuration  
-      マテリアル参照による置換、よりシンプルな設定
-    - Suitable when each source material consistently maps to one target material across all meshes  
-      各元マテリアルがすべてのメッシュで一貫して1つのターゲットマテリアルに対応する場合に適しています
-    - May not work correctly if the same source material needs to map to different targets in different slots  
-      同じ元マテリアルが異なるスロットで異なるターゲットに対応する必要がある場合、正しく動作しない可能性があります
-    - Use `[Optional] Create Material Swap (Per Object)` for more granular control if needed  
-      必要に応じて `[Optional] Create Material Swap (Per Object)` でより細かい制御が可能
+- **Material Copier & Material Swap Helper: Enhanced Object Matching Algorithm**
+  - Improved 4-stage priority matching system
+  - Added hierarchy depth tracking for better matching accuracy
+  - Added parent hierarchy filtering to narrow down candidates
+  - Added Levenshtein distance-based similarity scoring as final tiebreaker
+  - Added rootObjectName tracking for multiple object copy operations
+  - Updated Priority 2 from "same directory + cleaned name" to "same depth + exact name"
+  - Added Priority 4: Case-insensitive name matching
+  - Fixed issue where same-name objects in different branches could match incorrectly
+  - Improved matching accuracy for hierarchies with different depths
 
-### Improved / 改善
+### Changed
 
-- **Material Copier & Material Swap Helper: Enhanced Object Matching Algorithm**  
-  **Material Copier & Material Swap Helper: オブジェクトマッチングアルゴリズムを強化**
+- **MA Material Helper: Refactored codebase**
+  - Renamed from "Material Swap Helper" to "MA Material Helper" to reflect expanded functionality
+  - Reorganized namespace from `MaterialSwapHelper` to `MAMaterialHelper`
+  - Extracted common functionality into shared modules:
+    - `ObjectMatcher` - Object matching logic for both Material Swap and Material Setter
+    - `GenerationResult` - Unified result structure
+    - `ModularAvatarIntegration` - Enhanced MA component integration with parameter support
+  - Improved code maintainability and reusability
 
-  - Improved 4-stage priority matching system  
-    4段階優先度マッチングシステムを改善
-  - Added hierarchy depth tracking for better matching accuracy  
-    マッチング精度向上のため階層深度追跡を追加
-  - Added parent hierarchy filtering to narrow down candidates  
-    候補を絞り込むための親階層フィルタリングを追加
-  - Added Levenshtein distance-based similarity scoring as final tiebreaker  
-    最終的な判定基準としてLevenshtein距離ベースの類似度スコアリングを追加
-  - Added rootObjectName tracking for multiple object copy operations  
-    複数オブジェクトコピー操作用のrootObjectName追跡を追加
-  - Updated Priority 2 from "same directory + cleaned name" to "same depth + exact name"  
-    優先度2を「同階層+クリーニング後の名前」から「同じ深さ+完全名前一致」に変更
-  - Added Priority 4: Case-insensitive name matching  
-    優先度4を追加: 大文字小文字を区別しない名前マッチング
-  - Fixed issue where same-name objects in different branches could match incorrectly  
-    異なるブランチ内の同名オブジェクトが誤マッチする問題を修正
-  - Improved matching accuracy for hierarchies with different depths  
-    異なる深さの階層でのマッチング精度を向上
+- **MA Material Helper: Menu Reorganization**
+  - Reordered menu items to prioritize Material Setter as the recommended option
+  - Added `[Optional]` prefix to special case options (All Slots mode, Per Object mode)
+  - Material Setter is now recommended for most use cases
 
-### Changed / 変更
+---
 
-- **MA Material Helper: Refactored codebase**  
-  **MA Material Helper: コードベースをリファクタリング**
+### 追加
 
-  - Renamed from "Material Swap Helper" to "MA Material Helper" to reflect expanded functionality  
-    拡張された機能を反映するため「Material Swap Helper」から「MA Material Helper」に名称変更
-  - Reorganized namespace from `MaterialSwapHelper` to `MAMaterialHelper`  
-    名前空間を `MaterialSwapHelper` から `MAMaterialHelper` に再編成
-  - Extracted common functionality into shared modules:  
-    共通機能を共有モジュールに抽出:
-    - `ObjectMatcher` - Object matching logic for both Material Swap and Material Setter  
-      `ObjectMatcher` - Material SwapとMaterial Setter両方のオブジェクトマッチングロジック
-    - `GenerationResult` - Unified result structure  
-      `GenerationResult` - 統合された結果構造
-    - `ModularAvatarIntegration` - Enhanced MA component integration with parameter support  
-      `ModularAvatarIntegration` - パラメーター対応を含むMAコンポーネント統合の強化
-  - Improved code maintainability and reusability  
-    コードの保守性と再利用性を向上
+- **AO Bounds Setter: Anchor OverrideとBoundsの一括設定**
+  - メッシュのAnchor Override、Root Bone、Boundsを一括設定するAO Bounds Setterウィンドウを追加
+  - `Tools > Kanameliser Editor Plus > AO Bounds Setter` からアクセス
 
-- **MA Material Helper: Menu Reorganization**  
-  **MA Material Helper: メニュー構成の変更**
+- **MA Material Helper: Material Setter対応**
+  - 既存のMaterial Swapに加えてMaterial Setter自動生成機能を追加
+  - スロット単位で指定するため、同じメッシュ内で同一の元マテリアルから異なるマテリアルへの変更が可能
+  - Material Swapより正確にコピー元Prefabのマテリアル配置を再現
+  - 右クリックメニュー：`Kanameliser Editor Plus > Create Material Setter`
 
-  - Reordered menu items to prioritize Material Setter as the recommended option  
-    Material Setterを推奨オプションとして優先するようにメニュー項目を並び替え
-  - Added `[Optional]` prefix to special case options (All Slots mode, Per Object mode)  
-    特殊なケース向けオプション（全スロットモード、個別オブジェクトモード）に `[Optional]` 接頭辞を追加
-  - Material Setter is now recommended for most use cases  
-    ほとんどのケースでMaterial Setterが推奨されるようになりました
+- **MA Material Helper: Material Setter全スロットモード**
+  - 変更の有無に関係なく全マテリアルスロットを設定する必要がある場合のために全スロットモードを追加
+  - 標準モードは現在のマテリアルと異なるスロットのみを設定
+  - 右クリックメニュー：`[Optional] Create Material Setter (All Slots)`
+
+- **MA Material Helper: Material Swap と Material Setter - 使い分けガイド**
+  - **Material Setter（推奨）**:
+    - マテリアルスロット単位で設定するため、正確なマテリアル配置を保証
+    - 同じメッシュ内で同一の元マテリアルが異なるターゲットマテリアルに対応するケースに対応
+    - 混合マテリアルを含む複雑なPrefab構造でより信頼性が高い
+    - **迷ったら Material Setter を使用してください - すべてのシナリオで動作します**
+  - **Material Swap（オプション）**:
+    - マテリアル参照による置換、よりシンプルな設定
+    - 各元マテリアルがすべてのメッシュで一貫して1つのターゲットマテリアルに対応する場合に適しています
+    - 同じ元マテリアルが異なるスロットで異なるターゲットに対応する必要がある場合、正しく動作しない可能性があります
+    - 必要に応じて `[Optional] Create Material Swap (Per Object)` でより細かい制御が可能
+
+### 改善
+
+- **Material Copier & Material Swap Helper: オブジェクトマッチングアルゴリズムを強化**
+  - 4段階優先度マッチングシステムを改善
+  - マッチング精度向上のため階層深度追跡を追加
+  - 候補を絞り込むための親階層フィルタリングを追加
+  - 最終的な判定基準としてLevenshtein距離ベースの類似度スコアリングを追加
+  - 複数オブジェクトコピー操作用のrootObjectName追跡を追加
+  - 優先度2を「同階層+クリーニング後の名前」から「同じ深さ+完全名前一致」に変更
+  - 優先度4を追加: 大文字小文字を区別しない名前マッチング
+  - 異なるブランチ内の同名オブジェクトが誤マッチする問題を修正
+  - 異なる深さの階層でのマッチング精度を向上
+
+### 変更
+
+- **MA Material Helper: コードベースをリファクタリング**
+  - 拡張された機能を反映するため「Material Swap Helper」から「MA Material Helper」に名称変更
+  - 名前空間を `MaterialSwapHelper` から `MAMaterialHelper` に再編成
+  - 共通機能を共有モジュールに抽出:
+    - `ObjectMatcher` - Material SwapとMaterial Setter両方のオブジェクトマッチングロジック
+    - `GenerationResult` - 統合された結果構造
+    - `ModularAvatarIntegration` - パラメーター対応を含むMAコンポーネント統合の強化
+  - コードの保守性と再利用性を向上
+
+- **MA Material Helper: メニュー構成の変更**
+  - Material Setterを推奨オプションとして優先するようにメニュー項目を並び替え
+  - 特殊なケース向けオプション（全スロットモード、個別オブジェクトモード）に `[Optional]` 接頭辞を追加
+  - ほとんどのケースでMaterial Setterが推奨されるようになりました
 
 ## [0.3.1] - 2025-09-07
 
-### Fixed / 修正
+### Fixed
 
-- **Material Swap Helper: Fixed Object Matching Issues**  
-  **Material Swap Helper: オブジェクトマッチングの問題を修正**
-  - Fixed incorrect matching with Armature bones that have similar names to mesh objects  
-    メッシュオブジェクトと類似名のArmatureボーンとの誤マッチング問題を修正
-  - Fixed matching algorithm  
-    マッチングアルゴリズムを修正
-  - **Priority 1**: Exact relative path match + Renderer present  
-    **優先度1**: 相対パスの完全一致 + Renderer有り
-  - **Priority 2**: Same directory + cleaned name match + Renderer present  
-    **優先度2**: 同階層でクリーニング後の名前一致 + Renderer有り
-  - **Priority 3**: Exact name match + Renderer present  
-    **優先度3**: 名前の完全一致 + Renderer有り
-  - **Priority 4**: Cleaned name match + Renderer present  
-    **優先度4**: クリーニング後の名前一致 + Renderer有り
+- **Material Swap Helper: Fixed Object Matching Issues**
+  - Fixed incorrect matching with Armature bones that have similar names to mesh objects
+  - Fixed matching algorithm
+  - **Priority 1**: Exact relative path match + Renderer present
+  - **Priority 2**: Same directory + cleaned name match + Renderer present
+  - **Priority 3**: Exact name match + Renderer present
+  - **Priority 4**: Cleaned name match + Renderer present
+
+---
+
+### 修正
+
+- **Material Swap Helper: オブジェクトマッチングの問題を修正**
+  - メッシュオブジェクトと類似名のArmatureボーンとの誤マッチング問題を修正
+  - マッチングアルゴリズムを修正
+  - **優先度1**: 相対パスの完全一致 + Renderer有り
+  - **優先度2**: 同階層でクリーニング後の名前一致 + Renderer有り
+  - **優先度3**: 名前の完全一致 + Renderer有り
+  - **優先度4**: クリーニング後の名前一致 + Renderer有り
 
 ## [0.3.0] - 2025-07-14
 
-### Added / 追加
+### Added
 
-- Material Copier feature for copying materials between GameObjects via right-click context menu  
-  右クリックメニューからGameObject間でマテリアルをコピーするMaterial Copier機能を追加
-- Usage:
+- **Material Copier** — Copy materials between GameObjects via right-click context menu
   - (Step1) Select source objects in Hierarchy → Right-click → Copy Materials
-  - (Step2) Select target objects → Right-click → Paste Materials  
-  使用方法：  
+  - (Step2) Select target objects → Right-click → Paste Materials
+  - Context menu: `Kanameliser Editor Plus > Copy/Paste Materials`
+
+- **Material Swap Helper** — Automatic color change menu creation using Modular Avatar
+  - Creates color variation menus from color prefabs with automatic object matching
+  - Two creation modes: unified Material Swap components and per-object components
+  - (Step1) Select color variation prefabs → Right-click → Copy Material Setup
+  - (Step2) Select target avatar → Right-click → Create Material Swap
+  - Context menu: `Kanameliser Editor Plus > Copy Material Setup / Create Material Swap`
+  - Requires Modular Avatar 1.13.0 or later to be installed
+
+---
+
+### 追加
+
+- **Material Copier** — 右クリックメニューからGameObject間でマテリアルをコピー
   - (Step1) ヒエラルキーでコピー元オブジェクトを選択 → 右クリック → Copy Materials
   - (Step2) ペースト先オブジェクトを選択 → 右クリック → Paste Materials
-- Context menu : `Kanameliser Editor Plus > Copy/Paste Materials`  
-  コンテキストメニュー：`Kanameliser Editor Plus > Copy/Paste Materials`
+  - コンテキストメニュー：`Kanameliser Editor Plus > Copy/Paste Materials`
 
-- Material Swap Helper feature for automatic color change menu creation using Modular Avatar  
-  Modular Avatarを使用した色変更メニュー自動生成機能Material Swap Helperを追加
-- Creates color variation menus from color prefabs with automatic object matching  
-  カラーバリエーションのPrefabから色変更メニューを作成
-- Two creation modes: unified Material Swap components and per-object components  
-  統合型と個別オブジェクト型の2つのMaterial Swapコンポーネント作成モード
-- Usage:
-  - (Step1) Select color variation prefabs → Right-click → Copy Material Setup
-  - (Step2) Select target avatar → Right-click → Create Material Swap  
-  使用方法：  
+- **Material Swap Helper** — Modular Avatarを使用した色変更メニュー自動生成機能
+  - カラーバリエーションのPrefabから色変更メニューを作成
+  - 統合型と個別オブジェクト型の2つのMaterial Swapコンポーネント作成モード
   - (Step1) カラーバリエーションPrefabを選択 → 右クリック → Copy Material Setup
   - (Step2) ターゲットAvatarを選択 → 右クリック → Create Material Swap
-- Context menu: `Kanameliser Editor Plus > Copy Material Setup / Create Material Swap`  
-  コンテキストメニュー：`Kanameliser Editor Plus > Copy Material Setup / Create Material Swap`
-- Requires Modular Avatar 1.13.0 or later to be installed  
-  利用にはModular Avatar 1.13.0以上のインストールが必要
-
+  - コンテキストメニュー：`Kanameliser Editor Plus > Copy Material Setup / Create Material Swap`
+  - 利用にはModular Avatar 1.13.0以上のインストールが必要
 
 ## [0.3.0-rc.3] - 2025-07-13
 
-### Fixed / 修正
+### Fixed
 
-- Corrected Modular Avatar minimum version requirement from 1.8.0 to 1.13.0  
-  Modular Avatar最小バージョン要件を1.8.0から1.13.0に修正
+- Corrected Modular Avatar minimum version requirement from 1.8.0 to 1.13.0
+
+---
+
+### 修正
+
+- Modular Avatar最小バージョン要件を1.8.0から1.13.0に修正
 
 ## [0.3.0-rc.2] - 2025-07-13
 
-### Fixed / 修正
+### Fixed
 
-- Added missing Modular Avatar minimum version requirement (1.8.0+) to assembly definition  
-  アセンブリ定義に不足していたModular Avatar最小バージョン要件（1.8.0以上）を追加
+- Added missing Modular Avatar minimum version requirement (1.8.0+) to assembly definition
+
+---
+
+### 修正
+
+- アセンブリ定義に不足していたModular Avatar最小バージョン要件（1.8.0以上）を追加
 
 ## [0.3.0-rc.1] - 2025-07-13
 
-### Added / 追加
+### Added
 
-- Material Copier feature for copying materials between GameObjects via right-click context menu  
-  右クリックメニューからGameObject間でマテリアルをコピーするMaterial Copier機能を追加
-- Usage:
+- **Material Copier** — Copy materials between GameObjects via right-click context menu
   - (Step1) Select source objects in Hierarchy → Right-click → Copy Materials
-  - (Step2) Select target objects → Right-click → Paste Materials  
-  使用方法：  
+  - (Step2) Select target objects → Right-click → Paste Materials
+  - Context menu: `Kanameliser Editor Plus > Copy/Paste Materials`
+
+- **Material Swap Helper** — Automatic color change menu creation using Modular Avatar
+  - Creates color variation menus from color prefabs with automatic object matching
+  - Two creation modes: unified Material Swap components and per-object components
+  - (Step1) Select color variation prefabs → Right-click → Copy Material Setup
+  - (Step2) Select target avatar → Right-click → Create Material Swap
+  - Context menu: `Kanameliser Editor Plus > Copy Material Setup / Create Material Swap`
+  - Requires Modular Avatar package to be installed
+
+---
+
+### 追加
+
+- **Material Copier** — 右クリックメニューからGameObject間でマテリアルをコピー
   - (Step1) ヒエラルキーでコピー元オブジェクトを選択 → 右クリック → Copy Materials
   - (Step2) ペースト先オブジェクトを選択 → 右クリック → Paste Materials
-- Context menu : `Kanameliser Editor Plus > Copy/Paste Materials`  
-  コンテキストメニュー：`Kanameliser Editor Plus > Copy/Paste Materials`
+  - コンテキストメニュー：`Kanameliser Editor Plus > Copy/Paste Materials`
 
-- Material Swap Helper feature for automatic color change menu creation using Modular Avatar  
-  Modular Avatarを使用した色変更メニュー自動生成機能Material Swap Helperを追加
-- Creates color variation menus from color prefabs with automatic object matching  
-  カラーバリエーションのPrefabから色変更メニューを作成
-- Two creation modes: unified Material Swap components and per-object components  
-  統合型と個別オブジェクト型の2つのMaterial Swapコンポーネント作成モード
-- Usage:
-  - (Step1) Select color variation prefabs → Right-click → Copy Material Setup
-  - (Step2) Select target avatar → Right-click → Create Material Swap  
-  使用方法：  
+- **Material Swap Helper** — Modular Avatarを使用した色変更メニュー自動生成機能
+  - カラーバリエーションのPrefabから色変更メニューを作成
+  - 統合型と個別オブジェクト型の2つのMaterial Swapコンポーネント作成モード
   - (Step1) カラーバリエーションPrefabを選択 → 右クリック → Copy Material Setup
   - (Step2) ターゲットAvatarを選択 → 右クリック → Create Material Swap
-- Context menu: `Kanameliser Editor Plus > Copy Material Setup / Create Material Swap`  
-  コンテキストメニュー：`Kanameliser Editor Plus > Copy Material Setup / Create Material Swap`
-- Requires Modular Avatar package to be installed  
-  利用にはModular Avatarパッケージのインストールが必要
+  - コンテキストメニュー：`Kanameliser Editor Plus > Copy Material Setup / Create Material Swap`
+  - 利用にはModular Avatarパッケージのインストールが必要
 
 ## [0.2.1] - 2025-07-12
 
-### Fixed / 修正
+### Fixed
 
-- Fixed incorrect changelog URL in package.json  
-  package.jsonのchangelog URLの修正
+- Fixed incorrect changelog URL in package.json
+
+---
+
+### 修正
+
+- package.jsonのchangelog URLの修正
 
 ## [0.2.0] - 2025-07-12
 
-### Added / 追加
+### Added
 
-- Added changelog documentation (CHANGELOG.md)  
-  変更履歴ドキュメント（CHANGELOG.md）を追加
-- Added NDMF preview support to Mesh Info Display  
-  Mesh Info DisplayにNDMFプレビュー対応を追加
-- Shows optimized mesh information when NDMF preview is active  
-  NDMFプレビュー有効時に最適化後のメッシュ情報を表示
-- Preview effects of optimization tools like AAO and TexTransTool before building  
-  AAOやTexTransToolなどの最適化ツールの効果を事前確認可能に
-- Green dot indicator appears when preview is active  
-  プレビュー有効時は左上に緑のドットで表示
-- Only available when NDMF is installed  
-  NDMFがインストールされている場合のみ利用可能
+- Added changelog documentation (CHANGELOG.md)
+- Added NDMF preview support to Mesh Info Display
+  - Shows optimized mesh information when NDMF preview is active
+  - Preview effects of optimization tools like AAO and TexTransTool before building
+  - Green dot indicator appears when preview is active
+  - Only available when NDMF is installed
 
-### Changed / 変更
+### Changed
 
-- Improved mesh analysis accuracy for complex hierarchies  
-  複雑な階層におけるメッシュ解析精度の向上
-- Optimized update cycles for better editor performance  
-  エディタパフォーマンス向上のための更新サイクル最適化
-- Better error handling and reliability  
-  エラーハンドリングと信頼性の向上
+- Improved mesh analysis accuracy for complex hierarchies
+- Optimized update cycles for better editor performance
+- Better error handling and reliability
 
-### Technical / 技術的変更
+### Technical
 
-- Split monolithic MeshInfoDisplay into specialized classes:  
-  モノリシックなMeshInfoDisplayを各クラスに分割:
-  - `MeshInfoCalculator` - Core calculation logic / コア計算ロジック
-  - `MeshInfoConstants` - UI constants and styling / UI定数とスタイリング
-  - `MeshInfoData` - Data structures / データ構造
-  - `MeshInfoNDMFIntegration` - NDMF integration / NDMF統合
-  - `MeshInfoRenderer` - UI rendering / UIレンダリング
-  - `MeshInfoUtility` - Utility functions / ユーティリティ関数
-- Added `NDMFPreviewHelper` for NDMF preview integration  
-  NDMFプレビュー統合のための`NDMFPreviewHelper`を追加
-- Conditional compilation support for optional NDMF dependency  
-  NDMF依存関係の条件付きコンパイル
-- Assembly definition updates with version define detection  
-  バージョン定義検出を含むアセンブリ定義の更新
+- Split monolithic MeshInfoDisplay into specialized classes:
+  - `MeshInfoCalculator` - Core calculation logic
+  - `MeshInfoConstants` - UI constants and styling
+  - `MeshInfoData` - Data structures
+  - `MeshInfoNDMFIntegration` - NDMF integration
+  - `MeshInfoRenderer` - UI rendering
+  - `MeshInfoUtility` - Utility functions
+- Added `NDMFPreviewHelper` for NDMF preview integration
+- Conditional compilation support for optional NDMF dependency
+- Assembly definition updates with version define detection
+
+---
+
+### 追加
+
+- 変更履歴ドキュメント（CHANGELOG.md）を追加
+- Mesh Info DisplayにNDMFプレビュー対応を追加
+  - NDMFプレビュー有効時に最適化後のメッシュ情報を表示
+  - AAOやTexTransToolなどの最適化ツールの効果を事前確認可能に
+  - プレビュー有効時は左上に緑のドットで表示
+  - NDMFがインストールされている場合のみ利用可能
+
+### 変更
+
+- 複雑な階層におけるメッシュ解析精度の向上
+- エディタパフォーマンス向上のための更新サイクル最適化
+- エラーハンドリングと信頼性の向上
+
+### 技術的変更
+
+- モノリシックなMeshInfoDisplayを各クラスに分割:
+  - `MeshInfoCalculator` - コア計算ロジック
+  - `MeshInfoConstants` - UI定数とスタイリング
+  - `MeshInfoData` - データ構造
+  - `MeshInfoNDMFIntegration` - NDMF統合
+  - `MeshInfoRenderer` - UIレンダリング
+  - `MeshInfoUtility` - ユーティリティ関数
+- NDMFプレビュー統合のための`NDMFPreviewHelper`を追加
+- NDMF依存関係の条件付きコンパイル
+- バージョン定義検出を含むアセンブリ定義の更新
 
 ## [0.1.1] - 2025-05-30
 
-### Added / 追加
+### Added
 
-- Japanese README documentation (README.ja.md)  
-  日本語READMEドキュメント（README.ja.md）
+- Japanese README documentation (README.ja.md)
 
-### Changed / 変更
+### Changed
 
-- Updated installation instructions for clarity  
-  明確性のためのインストール手順の更新
-- Improved README documentation with usage tips  
-  使用上のヒントを含むREADMEドキュメントの改善
+- Updated installation instructions for clarity
+- Improved README documentation with usage tips
+
+---
+
+### 追加
+
+- 日本語READMEドキュメント（README.ja.md）
+
+### 変更
+
+- 明確性のためのインストール手順の更新
+- 使用上のヒントを含むREADMEドキュメントの改善
 
 ## [0.1.0] - 2024-05-27
 
-### Added / 追加
+Initial release of Kanameliser Editor Plus.
 
-- Initial release of Kanameliser Editor Plus  
-  Kanameliser Editor Plusの初回リリース
-- Mesh Info Display feature with polygon and material counting  
-  ポリゴンとマテリアルカウント機能付きMesh Info Display
-- Toggle Objects Active functionality with Ctrl+G shortcut  
-  Ctrl+Gショートカット付きToggle Objects Active機能
-- Component Manager for batch component operations  
-  一括コンポーネント操作のためのComponent Manager
-- Missing BlendShape Inserter for animation compatibility  
-  アニメーション互換性のためのMissing BlendShape Inserter
-- VRChat Creator Companion package support  
-  VRChat Creator Companionパッケージサポート
+### Added
 
-### Features / 機能
+- **Mesh Info Display** — Real-time mesh information display in Scene view with polygon and material counting
+- **Toggle Objects Active** — GameObject active state and EditorOnly tag toggling with Ctrl+G shortcut
+- **Component Manager** — Batch component operations with component listing and management across object hierarchies, with search functionality
+- **Missing BlendShape Inserter** — BlendShape key insertion for animation files for animation compatibility
+- VRChat Creator Companion package support
 
-- Real-time mesh information display in Scene view  
-  シーンビューでのリアルタイムメッシュ情報表示
-- GameObject active state and EditorOnly tag toggling  
-  GameObjectアクティブ状態とEditorOnlyタグの切り替え
-- Component listing and management across object hierarchies  
-  オブジェクト階層全体でのコンポーネント一覧と管理
-- BlendShape key insertion for animation files  
-  アニメーションファイルのBlendShapeキー挿入
-- Search functionality in Component Manager  
-  Component Managerの検索機能
+---
+
+Kanameliser Editor Plusの初回リリース。
+
+### 追加
+
+- **Mesh Info Display** — シーンビューでのリアルタイムメッシュ情報表示（ポリゴン・マテリアルカウント機能付き）
+- **Toggle Objects Active** — Ctrl+Gショートカット付きGameObjectアクティブ状態とEditorOnlyタグの切り替え
+- **Component Manager** — オブジェクト階層全体でのコンポーネント一覧と管理、検索機能付き一括コンポーネント操作
+- **Missing BlendShape Inserter** — アニメーション互換性のためのアニメーションファイルへのBlendShapeキー挿入
+- VRChat Creator Companionパッケージサポート

--- a/Editor/MeshInfo/MeshInfoDisplay.cs
+++ b/Editor/MeshInfo/MeshInfoDisplay.cs
@@ -32,7 +32,7 @@ namespace Kanameliser.EditorPlus
             EditorApplication.quitting += OnEditorQuitting;
         }
 
-        [MenuItem(MeshInfoConstants.MenuPath)]
+        [MenuItem(MeshInfoConstants.MenuPath, false, 1100)]
         private static void ToggleDisplayVisibility()
         {
             isDisplayVisible = !isDisplayVisible;

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,7 +2,7 @@
 
 UnityおよびVRChatのための便利なエディター拡張機能セット。
 
-## 🚩 インストール方法
+## インストール方法
 
 ### VRChat Creator Companion経由（推奨）
 
@@ -12,230 +12,162 @@ UnityおよびVRChatのための便利なエディター拡張機能セット。
 
 ### 手動インストール
 
-手動インストールする場合：
-
-1. [GitHub Releases](https://github.com/kxn4t/kanameliser-editor-plus/releases) から最新リリースをダウンロード
+1. [GitHub Releases](https://github.com/kxn4t/kanameliser-editor-plus/releases)から最新リリースをダウンロード
 2. パッケージをUnityプロジェクトにインポート
 
-## 📌 機能
+## 機能
 
-### 🔍 Mesh Info Display
+### Mesh Info Display
 
-- 選択したオブジェクトとその子オブジェクトの詳細なメッシュ情報を表示
-- ポリゴン数、マテリアル数、マテリアルスロット、メッシュ数を表示
-- シーンビューの左上に表示
-- `Tools > Kanameliser Editor Plus > Show Mesh Info Display` で表示/非表示を切り替え
+選択したオブジェクトとその子オブジェクトのメッシュ情報をシーンビュー左上に表示します。
+ポリゴン数・マテリアル数・マテリアルスロット数・メッシュ数を確認できます。
 
-#### 🔮 NDMFプレビュー対応
+#### NDMFプレビュー対応
 
-- **ビルド時統計**: NDMFプレビューがアクティブな時、プレビュー表示状態のメッシュデータを表示
-- **最適化の可視化**: 元のメッシュ数と最適化後のメッシュ数を視覚的な差分と併せて並列表示
-- **プレビュー中検出**: NDMFプロキシメッシュを自動検出し、緑のドットでプレビュー中かわかりやすく
+NDMFプレビューがアクティブな場合、AAO/TTT/Meshiaなどの最適化結果を確認しながら調整できます。
 
-### 🔄 Toggle Objects Active
+- 最適化前後のメッシュ数の差分を並列表示
+- NDMFプロキシメッシュを自動検出し、緑のドットでプレビュー中であることを表示
 
-- GameObjectのアクティブ状態とEditorOnlyタグをすばやく切り替え
-- ショートカット：`Ctrl+G`
+表示切替: `Tools > Kanameliser Editor Plus > Show Mesh Info Display`
 
-### 🧩 Component Manager
+### Toggle Objects Active
 
-- 選択したオブジェクトとその子オブジェクトのすべてのコンポーネントをリスト表示
+GameObjectのアクティブ状態とEditorOnlyタグをすばやく切り替えます。
+
+ショートカット: `Ctrl+G`
+
+### Component Manager
+
+選択したオブジェクトとその子オブジェクトの全コンポーネントを一覧表示します。
+
 - 特定のオブジェクトやコンポーネントタイプを検索
 - どのコンポーネントがどのオブジェクトに付いているかを瞬時に確認
-- 複数のオブジェクトを同時に選択して一括編集
+- 複数オブジェクトを同時に選択して一括編集
 - 不要なコンポーネントを簡単に一括削除
-- `Tools > Kanameliser Editor Plus > Component Manager` からアクセス
 
-### 🎨 Material Copier
-
-- 複数選択したGameObjectから同名のGameObjectへマテリアルをコピー&ペースト
-- FBXセットアップ時や、衣装対応時のカラーバリエーション対応が一瞬で可能に
-- MeshRendererとSkinnedMeshRendererコンポーネントの両方に対応
-- ヒエラルキー上右クリックメニューからアクセス：`Kanameliser Editor Plus > Copy/Paste Materials`
-
-### 🔄 MA Material Helper
-
-Modular Avatarのマテリアル制御コンポーネントを使用した色変更メニューの自動作成ツール。
-
-#### Material Setter（ほとんどのケースで推奨）
-- Modular AvatarのMaterial Setterコンポーネントを使用した色変更メニューの自動作成
-- カラーバリエーションのPrefabから直接マテリアルを設定するメニューを生成
-- Material Swapと異なり、メッシュの各マテリアルスロットに対して直接置き換える方式で動作
-  - スロット単位で指定するため、同じメッシュ内で同一の元マテリアルから異なるマテリアルへの変更が可能
-  - Material Swapより正確にコピー元Prefabのマテリアル配置を再現
-- 2つの作成モード：
-  - **標準モード**: 現在のマテリアルと異なるマテリアルスロットのみにSetterを作成
-  - **全スロットモード**: 現在のマテリアルとの差異に関係なくすべてのマテリアルスロットにSetterを作成
-
-#### Material Swap
-- Modular AvatarのMaterial Swapコンポーネントを使用した色変更メニューの自動作成
-- カラーバリエーションのPrefabから数クリックでメニューアイテムを生成
-- 複数のカラーバリエーションPrefabから同時にメニュー生成が可能
-- 2つの作成モード：統合型と個別オブジェクト型のMaterial Swapコンポーネント
-
-**共通仕様:**
-- [Modular Avatar](https://modular-avatar.nadena.dev/ja) 1.13.0以上のインストールが必要
-- ヒエラルキー上右クリックメニューからアクセス：`Kanameliser Editor Plus > Copy Material Setup / Create Material Setter / Create Material Swap`
-
-### 🎯 AO Bounds Setter
-
-- 複数のメッシュのAnchor Override、Root Bone、Boundsを一括設定
-- `Tools > Kanameliser Editor Plus > AO Bounds Setter` からアクセス
-
-### 😀 Missing BlendShape Inserter
-
-- アニメーションファイル間で不足しているBlendShapeキーを自動検出して修正
-- シェイプキーによる表情の破綻や破損したアニメーションを防止
-- 複数のアニメーションファイルの一括処理をサポート
-- `Tools > Kanameliser Editor Plus > Missing BlendShape Inserter` からアクセス
-- この機能は拡張ワークフローオプションのため [Zatools](https://zatools.kb10uy.dev/) とも統合されています
-- 詳しい説明は [Zatools/missing-blendshape-inserter](https://zatools.kb10uy.dev/editor-extension/missing-blendshape-inserter/) を参照してください
-
-## 🔧 使用上のヒント
+アクセス: `Tools > Kanameliser Editor Plus > Component Manager`
 
 ### Material Copier
 
-複数の類似オブジェクト間でのマテリアル管理に最適：
+複数選択したGameObjectから同名のGameObjectへマテリアルをコピー&ペーストできます。
 
-1. **コピー**: コピー元GameObjectを選択（例：Avatar_A、Avatar_B）→ 右クリック → `Copy Materials`
-2. **ペースト**: コピー先GameObjectを選択（例：Avatar_C、Avatar_D）→ 右クリック → `Paste Materials`
-3. **マッチング**: 同名のオブジェクトにマテリアルが適用されます（例："Head" → "Head"、"Body" → "body"）
+- FBXセットアップや衣装のカラーバリエーション対応が一瞬で可能
+- MeshRendererとSkinnedMeshRendererの両方に対応
 
-よくある使用例：
-- 異なるアバターバリアント間での衣装マテリアルのコピー
+#### 使い方
+
+1. コピー元のGameObjectを選択（複数選択可）→ 右クリック → `Copy Materials`
+2. コピー先のGameObjectを選択 → 右クリック → `Paste Materials`
+
+#### マッチング仕様
+
+コピー元とコピー先のオブジェクトは、以下の優先順位で自動的に対応付けられます。いずれもRendererを持つオブジェクトのみが対象です。
+
+1. **相対パスの完全一致（ルート名を除く）** — `Outfit/Jacket` → `Outfit/Jacket`
+2. **同じ階層深度での名前一致** — 親の名前が異なっていても、同名かつ同じ深度のオブジェクトを対応付け
+   - 例: `Outfit_A/Outer/Accessories/Earing`（深度3）→ `Outfit_B/Inner/Accessories/Earing`（深度3）
+3. **名前一致（深度不問）** — 複数候補がある場合はもっとも近い深度を優先
+   - 例: `Outfit/Outer/Jacket`（深度3）→ `Jacket`（深度1）
+4. **大文字小文字を区別しない名前一致** — `earing` → `Earing`
+
+複数の候補が残る場合は、親階層の名前を下から順にマッチングして絞り込みます。それでも決まらない場合は、ルート名のLevenshtein距離で最終選択します。
+
+この仕様はMA Material Helperのマッチングでも共通です。
+
+アクセス: ヒエラルキー右クリック `Kanameliser Editor Plus > Copy/Paste Materials`
 
 ### MA Material Helper
 
-既存のカラーバリエーションからアバターの色変更メニューを作成するのに最適：
+Modular Avatarのマテリアル制御コンポーネントを使用した色変更メニューを自動生成します。カラーバリエーションのPrefabから数クリックで色変更メニューを作成でき、複数のPrefabからの同時生成にも対応しています。
 
-1. **コピー**: カラーバリエーションPrefabを選択 → 右クリック → `Copy Material Setup`
-  Tips: カラーバリエーションPrefabを複数選択しても動作します
-2. **作成**: ターゲットとなる衣装を選択 → 右クリック → 以下のいずれかを選択
-   - `Create Material Setter` - Material Setterモード（ほとんどのケースで推奨）
-   - `[Optional] Create Material Setter (All Slots)` - Material Setterモード（全スロット）
-   - `Create Material Swap` - 標準のMaterial Swapモード
-   - `[Optional] Create Material Swap (Per Object)` - 個別オブジェクトのMaterial Swapモード
-3. **メニュー生成**: 番号付きカラーバリエーション（Color1、Color2など）を含む「Color Menu」を自動作成
+使用条件: [Modular Avatar](https://modular-avatar.nadena.dev/ja) 1.13.0以上
 
-**Material Setter モード:**
-- **標準モード**（推奨）: 現在のマテリアルと異なるマテリアルスロットのみを設定
-- **全スロットモード**: 現在のマテリアルとの差異に関係なくすべてのマテリアルスロットを設定
-  - パフォーマンスに影響を及ぼす可能性があるため、自分でカスタマイズしたい場合のみ利用を推奨
-- マテリアルを直接置き換える方式で、各オブジェクトにMaterial Setterコンポーネントを作成
+#### 使い方
 
-**Material Swap モード:**
-- **標準モード**: Material Swapコンポーネントを作成
-- **個別オブジェクトモード**: 各オブジェクト毎に個別のMaterial Swapコンポーネントを作成（複雑なセットアップに有用）
+1. カラーバリエーションPrefabを選択 → 右クリック → `Copy Material Setup`（複数選択可）
+2. ターゲットの衣装を選択 → 右クリック → 以下のいずれかを選択:
+   - `Create Material Setter` — 各スロットに直接マテリアルを設定（推奨）
+   - `[Optional] Create Material Setter (All Slots)` — すべてのスロットにSetterを作成（パフォーマンスに影響する可能性があるため、カスタマイズしたい場合のみ推奨）
+   - `Create Material Swap` — マテリアルの置き換えルールで設定
+   - `[Optional] Create Material Swap (Per Object)` — オブジェクト毎に個別のSwapを作成
 
-**Material SwapとMaterial Setterの使い分け:**
+番号付きカラーバリエーション（Color1、Color2など）を含む「Color Menu」が自動作成されます。
 
-どちらのモードを使うべきか迷ったら、以下を参考にしてください。  
+#### Material SetterとMaterial Swapの違い
+
 基本的にはMaterial Setterを推奨します。
 
+- **Material Setter**: スロット単位で設定するため、同一メッシュ内で同じマテリアルからそれぞれ異なるマテリアルへの変更が可能
+- **Material Swap**: マテリアル名ベースで置き換えるため、同一マテリアルは同じ変更先になる。シンプルな構成向け
+
+#### どちらを選ぶべきか
+
+**Material Setterを使う場合（ほとんどのケース）:**
+
+- 同一メッシュ内の異なるスロットで同じマテリアルを使用しているが、それぞれ別のマテリアルに変更したい
+- コピー元のマテリアル配置をより正確に再現したい
+- Material Swapで意図しない動作が発生する場合
+
 **Material Swapを使う場合:**
+
 - 同一メッシュ内で同じマテリアルスロットが変更先含めすべて同じマテリアルを使用している
 - シンプルなマテリアル構成
 
-**Material Setterを使う場合:**
-- 同一メッシュ内の異なるスロットで同じマテリアルを使用しているが、それぞれ別のマテリアルに変更したい
-- より正確にコピー元のマテリアル配置を再現したい
-- Material Swapで意図しない動作が発生する場合
+Material Swapでは以下のようなケースに対応できません:
 
-**Material Swapの制限**
 ```
 メッシュA:
   スロット0: マテリアルX → マテリアルY に変更したい
   スロット1: マテリアルX → マテリアルZ に変更したい
 ```
-この場合、Material Swapでは「マテリアルX」を1つのマテリアルにしか置き換えられないため、両方のスロットが同じマテリアルになってしまいます。  
-Material Setterではスロット単位で指定できるため、それぞれ異なるマテリアルに変更できます。
 
-**マッチング仕様:**
+Material Swapは「マテリアルX」を1つのマテリアルにしか置き換えられないため、両スロットが同じ結果になります。Material Setterならスロット単位で異なるマテリアルを指定できます。
 
-コピー元とコピー先のオブジェクトのマッチングは以下の優先順位で行われます：
-
-1. **優先度1**: 相対パスの完全一致（ルート名除外）+ Renderer有り
-   - 例: コピー元 `Outfit/Jacket` → ターゲット `Outfit/Jacket`
-   - 例: コピー元 `Accessories/Earing/Left` → ターゲット `Accessories/Earing/Left`
-
-2. **優先度2**: 同じ階層深度 + 完全名前一致 + Renderer有り
-   - 例: コピー元 `Outfit_A/Outer/Accessories/Earing`（深度=3）→ ターゲット `Outfit_B/Inner/Accessories/Earing`（深度=3）
-   - 親の名前が異なっていても、どちらも `Earing` という名前で同じ深度
-   - 同じ深度に複数候補がある場合は階層フィルタリングを適用
-
-3. **優先度3**: 完全名前一致 + Renderer有り
-   - 例: コピー元 `Outfit/Outer/Jacket`（深度=3）→ ターゲット `Jacket`（深度=1）
-   - 複数の `Jacket` が存在する場合、もっとも近い深度を選択
-   - コピー元が深度3で、ターゲット候補が深度1, 2, 4の場合: 深度2または4を優先（差=1）
-   - 複数候補がある場合は階層フィルタリングを適用
-
-4. **優先度4**: 大文字小文字を区別しない名前一致 + Renderer有り
-   - 例: コピー元 `earing` → ターゲット `Earing`
-   - 例: コピー元 `JACKET` → ターゲット `Jacket`
-   - もっとも近い深度を選択し、階層フィルタリングを適用
-
-**追加のマッチング:**
-
-優先度マッチング後も複数候補が残る場合：
-
-- **親階層フィルタリング**: 下から上へ親の名前をマッチング
-  - 例: `Outfit/Outer/Jacket` を探している場合
-    - 候補: `Outfit/Outer/Jacket`、`Costume/Outer/Jacket`、`Outfit/Inner/Jacket`
-    - 直接の親でフィルター: `Outer` 配下を優先 → 2候補が残る
-    - そのさらに親でフィルター: `Outfit` 配下を優先 → `Outfit/Outer/Jacket` が選択される
-- **類似度スコアリング**: Levenshtein距離を使用した最終選択
-  - 例: `Outfit_C` にペーストする場合、`Outfit_A` と `Outfit_C` 由来の候補がある
-    - ルート名を比較: `Outfit_C` vs `Outfit_A` と `Outfit_C` vs `Outfit_C`
-    - `Outfit_C` 由来のコピー元（距離=0）を `Outfit_A` 由来（距離=2）より優先
-
-よくある使用例：
-- アバター衣装の色変更メニューの作成
-- 既存のカラーバリエーションPrefabからの色変更メニューの一括作成
+アクセス: ヒエラルキー右クリック `Kanameliser Editor Plus > Copy Material Setup / Create Material Setter / Create Material Swap`
 
 ### AO Bounds Setter
 
-衣装製作やアバター制作時の一括設定に最適：
+複数メッシュのAnchor Override、Root Bone、Boundsを一括設定します。衣装製作やアバター制作時に便利です。
 
-1. **ウィンドウを開く**: `Tools > Kanameliser Editor Plus > AO Bounds Setter`
-2. **ルートオブジェクトを選択**: ヒエラルキー上のオブジェクトをRoot Objectフィールドにドラッグ
-3. **設定**:
-   - **Anchor Override**: アンカーポイントとして使用するオブジェクトを設定
-     - ドロップダウンでルートオブジェクト配下のオブジェクトを検索・選択可能
-   - **Root Bone**（SkinnedMeshRendererのみ）: SkinnedMeshのルートボーンを設定
-     - ドロップダウンでルートオブジェクト配下のオブジェクトを検索・選択可能
-   - **Bounds**（SkinnedMeshRendererのみ）: Boundsを設定
-4. **メッシュを選択**: チェックボックスを使用して設定を適用するメッシュを選択
-5. **適用**:「Apply to Selected Meshes」をクリックして設定を一括適用
+1. Root Objectフィールドにヒエラルキーのオブジェクトをドラッグ
+2. Anchor Override・Root Bone・Boundsを設定
+   - ドロップダウンの検索機能でルートオブジェクト配下のボーン/アンカーをすばやく選択できます
+3. チェックボックスで対象メッシュを選択し、「Apply to Selected Meshes」で一括適用
 
-**ヒント:**
-- オブジェクト名、Anchor Override、Root Boneのラベルをクリックすると、そのオブジェクトをヒエラルキー内で素早く選択できます
-- ドロップダウンの検索機能を使用して、ボーン/アンカーを素早く見つけられます
-- 設定はチェックされたメッシュにのみ適用されます
+オブジェクト名やAnchor Override、Root Boneのラベルをクリックすると、ヒエラルキー内でそのオブジェクトを選択できます。
+
+アクセス: `Tools > Kanameliser Editor Plus > AO Bounds Setter`
 
 ### Missing BlendShape Inserter
 
-複数のAnimationClip間で変更したBlendShapeの対象を標準化するツールです。主に以下の場合に使用します：
+アニメーションファイル間で不足しているBlendShapeキーを自動検出・補完します。
+すべてのアニメーションが同じBlendShapeを操作するようにファイルを更新することで、異なる表情状態間のスムーズな遷移を確保します。複数ファイルの一括処理にも対応しています。
 
-- アバターの顔のBlendShapeを変更したけど、表情アニメーションで使用していない場合
-- ジェスチャーなどによる表情アニメーション切り替え時に表情が崩れたり破綻する場合
-- すべてのアニメーションファイルで一貫したBlendShape操作を確保する必要がある場合
+主な使用場面:
 
-このツールは、すべてのアニメーション間で同じBlendShapeを操作するようにアニメーションファイルを更新することで、表情の歪みを防止し、異なる表情状態間のスムーズな遷移を確保します。
+- アバターの顔のBlendShapeを変更したが、表情アニメーションで使用していない場合
+- ジェスチャーなどによる表情アニメーション切り替え時に表情が崩れる場合
+- すべてのアニメーションファイルで一貫したBlendShape操作を確保したい場合
 
-## 📋 必要環境
+この機能はkb10uyさんの[Zatools](https://zatools.kb10uy.dev/)に多言語化対応され統合されています。詳しくは[Zatools/missing-blendshape-inserter](https://zatools.kb10uy.dev/editor-extension/missing-blendshape-inserter/)を参照してください。
+
+アクセス: `Tools > Kanameliser Editor Plus > Missing BlendShape Inserter`
+
+## 必要環境
 
 - Unity 2022.3.22f1以上
-- オプション: NDMF（Non-Destructive Modular Framework）でビルドプレビュー機能拡張
-- オプション: Modular Avatar 1.13.0以上（Material Swap Helper機能に必要）
+- オプション: NDMF（ビルドプレビュー機能拡張）
+- オプション: Modular Avatar 1.13.0以上（MA Material Helper機能に必要）
 
-## 🤝 貢献
+## 貢献
 
 お気軽にIssueまたはPull Requestを送信してください。
 
-## 📄 ライセンス
+## ライセンス
 
-MITライセンス - 詳細はLICENSEファイルをご覧ください。
+MITライセンス — 詳細はLICENSEファイルをご覧ください。
 
-## 👋 連絡先
+## 連絡先
 
-質問やフィードバックがある場合は、GitHubでissueを開くか、Xでお問い合わせください。
+質問やフィードバックがある場合は、GitHubでIssueを開くか、Xでお問い合わせください。

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Kanameliser Editor Plus
 
-A small set of useful Unity & VRChat editor extensions.
+A set of useful editor extensions for Unity and VRChat.
 
-## 🚩 Installation
+## Installation
 
 ### Via VRChat Creator Companion (Recommended)
 
@@ -12,228 +12,167 @@ A small set of useful Unity & VRChat editor extensions.
 
 ### Manual Installation
 
-If you prefer manual installation:
-
 1. Download the latest release from [GitHub Releases](https://github.com/kxn4t/kanameliser-editor-plus/releases)
 2. Import the package into your Unity project
 
-## 📌 Features
+## Features
 
-### 🔍 Mesh Info Display
+### Mesh Info Display
 
-- Displays detailed mesh information for selected objects and their children
-- Shows polygon count, material count, material slots, and mesh count
-- Appears in the top-left corner of the Scene view
-- Toggle visibility via `Tools > Kanameliser Editor Plus > Show Mesh Info Display`
+Displays mesh information for selected objects and their children in the top-left corner of the Scene view.
+You can check polygon count, material count, material slot count, and mesh count.
 
-#### 🔮 NDMF Preview Support
+#### NDMF Preview Support
 
-- **Build-time Statistics**: Shows preview mesh data when NDMF preview is active
-- **Optimization Visualization**: Displays both original and optimized mesh counts side-by-side with visual diff indicators
-- **Preview Detection**: Automatically detects NDMF proxy meshes and shows clear green dot indicator during preview
+When NDMF preview is active, you can check optimization results from AAO/TTT/Meshia and adjust accordingly.
 
-### 🔄 Toggle Objects Active
+- Displays original and optimized mesh counts side-by-side with diff indicators
+- Automatically detects NDMF proxy meshes and shows a green dot to indicate preview state
 
-- Quickly toggle between GameObject active state and EditorOnly tag
-- Shortcuts: `Ctrl+G`
+Toggle: `Tools > Kanameliser Editor Plus > Show Mesh Info Display`
 
-### 🧩 Component Manager
+### Toggle Objects Active
 
-- List all components on selected objects and their children
+Quickly toggle between GameObject active state and EditorOnly tag.
+
+Shortcut: `Ctrl+G`
+
+### Component Manager
+
+Lists all components on selected objects and their children.
+
 - Search for specific objects or component types
 - Instantly see which components are attached to which objects
 - Select multiple objects simultaneously for batch editing
-- Easily remove unwanted components
-- Access via `Tools > Kanameliser Editor Plus > Component Manager`
+- Easily remove unwanted components in bulk
 
-### 🎨 Material Copier
-
-- Copy & paste materials from multiple selected GameObjects to GameObjects with matching names
-- Perfect for instant FBX setup and outfit color variations
-- Supports both MeshRenderer and SkinnedMeshRenderer components
-- Access via right-click context menu in Hierarchy: `Kanameliser Editor Plus > Copy/Paste Materials`
-
-### 🔄 MA Material Helper
-
-Automatic color change menu creation tools using Modular Avatar's material control components.
-
-#### Material Setter (Recommended for most use cases)
-- Automatically create color change menus using Modular Avatar's Material Setter components
-- Generate menus that directly set materials from color variation prefabs
-- Operates differently from Material Swap by directly replacing materials on each material slot of meshes
-  - Allows changing from the same source material to different materials within the same mesh by specifying per-slot
-  - More accurately reproduces the material layout of the source prefab compared to Material Swap
-- Two creation modes:
-  - **Standard Mode**: Only creates setters for material slots that differ from the current materials
-  - **All Slots Mode**: Creates setters for all material slots regardless of whether they differ from current materials
-
-#### Material Swap
-- Automatically create color change menus using Modular Avatar's Material Swap components
-- Generate menu items from color variation prefabs with just a few clicks
-- Support for multiple color variation prefabs to create menus simultaneously
-- Two creation modes: unified and per-object Material Swap components
-
-**Common Specifications:**
-- Requires [Modular Avatar](https://modular-avatar.nadena.dev/) 1.13.0 or higher to be installed
-- Access via right-click context menu in Hierarchy: `Kanameliser Editor Plus > Copy Material Setup / Create Material Setter / Create Material Swap`
-
-### 🎯 AO Bounds Setter
-
-- Batch configuration of Anchor Override, Root Bone, and Bounds for multiple meshes
-- Access via `Tools > Kanameliser Editor Plus > AO Bounds Setter`
-
-### 😀 Missing BlendShape Inserter
-
-- Automatically detects and fixes missing BlendShape keys across animation files
-- Prevents facial expression glitches and broken animations
-- Supports batch processing of multiple animation files
-- Access via `Tools > Kanameliser Editor Plus > Missing BlendShape Inserter`
-- This functionality is also integrated with [Zatools](https://zatools.kb10uy.dev/) for expanded workflow options
-- For more detailed information, please refer to [Zatools/missing-blendshape-inserter](https://zatools.kb10uy.dev/editor-extension/missing-blendshape-inserter/)
-
-## 🔧 Usage Tips
+Access: `Tools > Kanameliser Editor Plus > Component Manager`
 
 ### Material Copier
 
-Perfect for managing materials across multiple similar objects:
+Copy & paste materials from multiple selected GameObjects to GameObjects with matching names.
 
-1. **Copy**: Select source GameObjects (e.g., Avatar_A, Avatar_B) → Right-click → `Copy Materials`
-2. **Paste**: Select target GameObjects (e.g., Avatar_C, Avatar_D) → Right-click → `Paste Materials`
-3. **Matching**: Materials are applied to objects with matching names (e.g., "Head" → "Head", "Body" → "body")
+- Instant FBX setup and outfit color variation support
+- Supports both MeshRenderer and SkinnedMeshRenderer
 
-Common use cases:
-- Copying outfit materials between different avatar variants
+#### Usage
+
+1. Select source GameObjects (multiple selection supported) → Right-click → `Copy Materials`
+2. Select target GameObjects → Right-click → `Paste Materials`
+
+Materials are applied to objects with matching names (e.g., `Head` → `Head`, `Body` → `body`).
+
+#### Matching Specifications
+
+Source and target objects are automatically matched in the following priority order. Only objects with a Renderer are considered.
+
+1. **Exact relative path match (excluding root name)** — `Outfit/Jacket` → `Outfit/Jacket`
+2. **Name match at the same hierarchy depth** — Matches objects with the same name and depth, even if parent names differ
+   - Example: `Outfit_A/Outer/Accessories/Earing` (depth 3) → `Outfit_B/Inner/Accessories/Earing` (depth 3)
+3. **Name match (any depth)** — When multiple candidates exist, the closest depth is preferred
+   - Example: `Outfit/Outer/Jacket` (depth 3) → `Jacket` (depth 1)
+4. **Case-insensitive name match** — `earing` → `Earing`
+
+When multiple candidates remain, parent names are matched from bottom to top to narrow down the results. If still ambiguous, the Levenshtein distance of root names is used for final selection.
+
+This matching specification is also shared by MA Material Helper.
+
+Access: Right-click in Hierarchy `Kanameliser Editor Plus > Copy/Paste Materials`
 
 ### MA Material Helper
 
-Perfect for creating avatar color change menus from existing color variations:
+Automatically generates color change menus using Modular Avatar's material control components. Create color change menus from color variation prefabs in just a few clicks, with support for simultaneous generation from multiple prefabs.
 
-1. **Copy**: Select color variation prefabs → Right-click → `Copy Material Setup`
-   Tips: Works with multiple color variation prefabs selected simultaneously
-2. **Create**: Select target outfit → Right-click → Choose one of the following:
-   - `Create Material Setter` - Standard Material Setter mode (recommended for most use cases)
-   - `[Optional] Create Material Setter (All Slots)` - Material Setter mode (all slots)
-   - `Create Material Swap` - Standard Material Swap mode
-   - `[Optional] Create Material Swap (Per Object)` - Per-object Material Swap mode
-3. **Menu Generation**: Automatically creates "Color Menu" with numbered color variations (Color1, Color2, etc.)
+Requirement: [Modular Avatar](https://modular-avatar.nadena.dev/) 1.13.0 or higher
 
-**Material Setter Modes:**
-- **Standard Mode** (recommended): Only sets material slots that differ from current materials
-- **All Slots Mode**: Sets all material slots regardless of whether they differ from current materials
-  - May affect performance, recommended only when you need to customize manually
-- Directly replaces materials by creating Material Setter components for each object
+#### Usage
 
-**Material Swap Modes:**
-- **Standard Mode**: Creates unified Material Swap components
-- **Per-Object Mode**: Creates individual Material Swap components for each object (useful for complex setups)
+1. Select color variation prefabs → Right-click → `Copy Material Setup` (multiple selection supported)
+2. Select target outfit → Right-click → Choose one of the following:
+   - `Create Material Setter` — Directly set materials per slot (recommended)
+   - `[Optional] Create Material Setter (All Slots)` — Create setters for all slots (may affect performance, recommended only when you need to customize manually)
+   - `Create Material Swap` — Set materials by replacement rules
+   - `[Optional] Create Material Swap (Per Object)` — Create individual swaps per object
 
-**Choosing Between Material Swap and Material Setter:**
+A "Color Menu" with numbered color variations (Color1, Color2, etc.) is automatically created.
 
-When deciding which mode to use, consider the following:
+#### Difference Between Material Setter and Material Swap
 
-**Use Material Swap when:**
-- All material slots within the same mesh use the same material, both before and after the change
-- Your material setup is simple
+Material Setter is recommended for most use cases.
 
-**Use Material Setter when:**
+- **Material Setter**: Sets per slot, allowing different materials to be assigned from the same source material within the same mesh
+- **Material Swap**: Replaces by material name, so the same source material always maps to the same target. Best for simple configurations
+
+#### Which Should You Choose?
+
+**Use Material Setter (most cases):**
+
 - Different slots in the same mesh use the same material but need to change to different materials
 - You want to more accurately reproduce the material layout from the source prefab
 - Material Swap produces unintended behavior
 
-**Material Swap Limitation**
+**Use Material Swap:**
+
+- All slots using the same material within a mesh should change to the same target material
+- Simple material configurations
+
+Material Swap cannot handle cases like:
+
 ```
 Mesh A:
   Slot 0: Material X → want to change to Material Y
   Slot 1: Material X → want to change to Material Z
 ```
-In this case, Material Swap can only replace "Material X" with one material, so both slots will end up with the same material.  
-Material Setter can specify per-slot, allowing each to change to different materials.
 
-**Matching Specifications:**
+Material Swap can only replace "Material X" with one material, so both slots end up with the same result. Material Setter can specify per slot, allowing each to change to a different material.
 
-The matching between source and target objects follows this priority order:
-
-1. **Priority 1**: Exact relative path match (without root name) + Renderer present
-   - Example: Source `Outfit/Jacket` → Target `Outfit/Jacket`
-   - Example: Source `Accessories/Earing/Left` → Target `Accessories/Earing/Left`
-
-2. **Priority 2**: Same hierarchy depth + exact name match + Renderer present
-   - Example: Source `Outfit_A/Outer/Accessories/Earing` (depth=3) → Target `Outfit_B/Inner/Accessories/Earing` (depth=3)
-   - Both objects are named `Earing` and at the same depth, even though parent names differ
-   - Applies hierarchy filtering if multiple candidates exist at the same depth
-
-3. **Priority 3**: Exact name match + Renderer present
-   - Example: Source `Outfit/Outer/Jacket` (depth=3) → Target `Jacket` (depth=1)
-   - Selects by closest depth if multiple `Jacket` objects exist
-   - If source is depth 3 and targets are depth 1, 2, 4: prefers depth 2 or 4 (difference=1)
-   - Applies hierarchy filtering if multiple candidates exist
-
-4. **Priority 4**: Case-insensitive name match + Renderer present
-   - Example: Source `earing` → Target `Earing`
-   - Example: Source `JACKET` → Target `Jacket`
-   - Selects by closest depth and applies hierarchy filtering
-
-**Advanced Matching:**
-
-When multiple candidates remain after priority matching:
-- **Parent hierarchy filtering**: Matches parent names from bottom to top
-  - Example: Looking for `Outfit/Outer/Jacket`
-    - Candidates: `Outfit/Outer/Jacket`, `Costume/Outer/Jacket`, `Outfit/Inner/Jacket`
-    - Filters by immediate parent: prefers candidates under `Outer` → 2 candidates remain
-    - Filters by grandparent: prefers candidates under `Outfit` → `Outfit/Outer/Jacket` selected
-- **Similarity scoring**: Uses Levenshtein distance for final selection
-  - Example: Pasting to `Outfit_C` with candidates from `Outfit_A` and `Outfit_C`
-    - Compares root names: `Outfit_C` vs `Outfit_A` and `Outfit_C` vs `Outfit_C`
-    - Prefers `Outfit_C` source (distance=0) over `Outfit_A` source (distance=2)
-
-Common use cases:
-- Creating color change menus for avatar outfits
-- Batch creation of color change menus from existing color variation prefabs
+Access: Right-click in Hierarchy `Kanameliser Editor Plus > Copy Material Setup / Create Material Setter / Create Material Swap`
 
 ### AO Bounds Setter
 
-Perfect for batch configuration during outfit creation or avatar setup:
+Batch configure Anchor Override, Root Bone, and Bounds for multiple meshes. Useful for outfit creation and avatar setup.
 
-1. **Open Window**: `Tools > Kanameliser Editor Plus > AO Bounds Setter`
-2. **Select Root Object**: Drag an object from the Hierarchy to the Root Object field
-3. **Configure Settings**:
+1. Drag an object from the Hierarchy to the Root Object field
+2. Configure settings:
    - **Anchor Override**: Set the object to use as the anchor point
-     - Use the dropdown to search and select from objects under the root object
    - **Root Bone** (SkinnedMeshRenderer only): Set the root bone for skinned meshes
-     - Use the dropdown to search and select from objects under the root object
    - **Bounds** (SkinnedMeshRenderer only): Configure bounds
-4. **Select Meshes**: Use checkboxes to select which meshes to apply settings to
-5. **Apply**: Click "Apply to Selected Meshes" to batch apply settings
+   - Use the dropdown search to quickly find bones/anchors under the root object
+3. Select target meshes with checkboxes and click "Apply to Selected Meshes" to batch apply
 
-**Tips:**
-- Click on object name, Anchor Override, or Root Bone labels to quickly select that object in the Hierarchy
-- Use the dropdown search function to quickly find bones/anchors
-- Settings only apply to checked meshes
+Click on object name, Anchor Override, or Root Bone labels to quickly select that object in the Hierarchy.
+
+Access: `Tools > Kanameliser Editor Plus > AO Bounds Setter`
 
 ### Missing BlendShape Inserter
 
-A tool that standardizes BlendShape targets across multiple AnimationClips. It's primarily used when:
+Automatically detects and fills in missing BlendShape keys across animation files.
+Updates all animations to operate on the same BlendShapes, ensuring smooth transitions between different expression states. Supports batch processing of multiple files.
 
-- You've modified your avatar's facial BlendShapes but kept the original animations
-- Your facial expressions break or glitch when switching between animations
+Common use cases:
+
+- You've modified your avatar's facial BlendShapes but haven't updated the expression animations
+- Facial expressions break or glitch when switching via gestures
 - You need to ensure consistent BlendShape manipulation across all animation files
 
-The tool works by updating Animation files to operate on the same BlendShapes across all animations, preventing facial distortions and ensuring smooth transitions between different expression states.
+This feature has been localized and integrated into [Zatools](https://zatools.kb10uy.dev/) by kb10uy. For details, see [Zatools/missing-blendshape-inserter](https://zatools.kb10uy.dev/editor-extension/missing-blendshape-inserter/).
 
-## 📋 Requirements
+Access: `Tools > Kanameliser Editor Plus > Missing BlendShape Inserter`
+
+## Requirements
 
 - Unity 2022.3.22f1 or higher
-- Optional: NDMF (Non-Destructive Modular Framework) for enhanced build preview support
-- Optional: Modular Avatar 1.13.0 or higher for Material Swap Helper feature
+- Optional: NDMF (enhanced build preview support)
+- Optional: Modular Avatar 1.13.0 or higher (required for MA Material Helper)
 
-## 🤝 Contributing
+## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
+Feel free to submit an Issue or Pull Request.
 
-## 📄 License
+## License
 
-MIT License - see the LICENSE file for details.
+MIT License — see the LICENSE file for details.
 
-## 👋 Contact
+## Contact
 
-If you have any questions or feedback, please open an issue on GitHub or contact me on X
+If you have any questions or feedback, please open an issue on GitHub or contact me on X.


### PR DESCRIPTION
## Summary
- Tools/Kanameliser Editor Plus/ メニューで、トグル項目（Show Mesh Info Display）が他の項目と並んでいて分かりづらかったため、区切り線で分離

## Changes
- `MenuItem` の priority を 1100 に設定し、他の項目（デフォルト 1000）との間に区切り線を表示するように変更
