### PR TITLE
fix: use Transform identity for matched-target dedup

### DIFF
--- a/Editor/MAMaterialHelper/Common/ObjectMatcher.cs
+++ b/Editor/MAMaterialHelper/Common/ObjectMatcher.cs
@@ -50,16 +50,17 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
         /// <param name="sourceRelativePath">Relative path of the source object from its root.</param>
         /// <param name="sourceDepth">Depth of the source object in its hierarchy.</param>
         /// <param name="sourceRootName">Name of the source root object for ancestor context scoring.</param>
-        /// <param name="matchedPaths">
-        /// Optional set of already-matched target paths (relative to root).
+        /// <param name="matchedTargets">
+        /// Optional set of already-matched target Transforms.
         /// Matched targets are excluded from candidates to prevent duplicate matching.
         /// The selected match is automatically added to this set.
+        /// Transform identity is used as the key, so same-name siblings are distinguished correctly.
         /// </param>
         /// <param name="sourceRendererType">
         /// Optional renderer type name (e.g. "SkinnedMeshRenderer", "MeshRenderer").
         /// When non-empty, candidates are filtered to match this renderer type.
         /// </param>
-        public static Transform FindMatchingObject(Transform root, string objectName, string sourceRelativePath, int sourceDepth = 0, string sourceRootName = "", HashSet<string> matchedPaths = null, string sourceRendererType = "")
+        public static Transform FindMatchingObject(Transform root, string objectName, string sourceRelativePath, int sourceDepth = 0, string sourceRootName = "", HashSet<Transform> matchedTargets = null, string sourceRendererType = "")
         {
             if (root == null) return null;
 
@@ -72,17 +73,17 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
                 .Where(t => string.IsNullOrEmpty(sourceRendererType) ||
                             t.GetComponent<Renderer>()?.GetType().Name == sourceRendererType)
                 .Select(t => (transform: t, path: GetRelativePathFromRoot(t, root)))
-                .Where(c => matchedPaths == null || !matchedPaths.Contains(c.path))
+                .Where(c => matchedTargets == null || !matchedTargets.Contains(c.transform))
                 .ToList();
             Debug.Log($"[MA Material Helper] MATCH: Objects with Renderer: {candidates.Count}" +
-                (matchedPaths != null ? $" (excluded {matchedPaths.Count} already matched)" : ""));
+                (matchedTargets != null ? $" (excluded {matchedTargets.Count} already matched)" : ""));
 
             var result = TryMatch(candidates, objectName, sourceRelativePath, sourceDepth, sourceRootName);
 
             if (result.transform != null)
             {
                 // Track matched target to prevent duplicate matching
-                matchedPaths?.Add(result.path);
+                matchedTargets?.Add(result.transform);
                 return result.transform;
             }
 
@@ -95,7 +96,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
                     .Where(t => t.GetComponent<Renderer>() != null)
                     .Where(t => t.GetComponent<Renderer>().GetType().Name != sourceRendererType)
                     .Select(t => (transform: t, path: GetRelativePathFromRoot(t, root)))
-                    .Where(c => matchedPaths == null || !matchedPaths.Contains(c.path))
+                    .Where(c => matchedTargets == null || !matchedTargets.Contains(c.transform))
                     .ToList();
 
                 if (crossTypeCandidates.Count > 0)
@@ -114,7 +115,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
                     {
                         var selected = SelectBestFuzzyCandidate(p5CrossType, objectName, sourceRelativePath, sourceDepth, sourceRootName);
                         Debug.Log($"[MA Material Helper] MATCH: P5 - Fuzzy (cross-type): '{selected.transform.name}' at '{GetFullPath(selected.transform)}'");
-                        matchedPaths?.Add(selected.path);
+                        matchedTargets?.Add(selected.transform);
                         return selected.transform;
                     }
                 }

--- a/Editor/MAMaterialHelper/MaterialSetter/MaterialSetterGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSetter/MaterialSetterGenerator.cs
@@ -189,13 +189,13 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSetter
         private static int SetupMaterialSettersForGroup(GameObject colorVariation, GameObject targetRoot, List<MaterialSetupData> group, bool skipUnchanged)
         {
             int totalMatchCount = 0;
-            var matchedPaths = new HashSet<string>();
+            var matchedTargets = new HashSet<Transform>();
 
             // Process each material setup in the group
             foreach (var sourceSetup in group)
             {
                 // Try to find matching object in target
-                var matchedTransform = ObjectMatcher.FindMatchingObject(targetRoot.transform, sourceSetup.objectName, sourceSetup.relativePath, sourceSetup.hierarchyDepth, sourceSetup.rootObjectName, matchedPaths, sourceSetup.rendererType);
+                var matchedTransform = ObjectMatcher.FindMatchingObject(targetRoot.transform, sourceSetup.objectName, sourceSetup.relativePath, sourceSetup.hierarchyDepth, sourceSetup.rootObjectName, matchedTargets, sourceSetup.rendererType);
                 if (matchedTransform == null)
                 {
                     Debug.LogWarning($"[MA Material Helper] Could not find match for '{sourceSetup.objectName}'");

--- a/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
@@ -414,13 +414,13 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
             errorMessage = null;
             var materialSwapData = new Dictionary<Material, MaterialSwapInfo>();
             int totalMatchCount = 0;
-            var matchedPaths = new HashSet<string>();
+            var matchedTargets = new HashSet<Transform>();
 
             // Process each material setup in the group
             foreach (var sourceSetup in group)
             {
                 // Try to find matching object in target
-                var matchedTransform = ObjectMatcher.FindMatchingObject(targetRoot.transform, sourceSetup.objectName, sourceSetup.relativePath, sourceSetup.hierarchyDepth, sourceSetup.rootObjectName, matchedPaths, sourceSetup.rendererType);
+                var matchedTransform = ObjectMatcher.FindMatchingObject(targetRoot.transform, sourceSetup.objectName, sourceSetup.relativePath, sourceSetup.hierarchyDepth, sourceSetup.rootObjectName, matchedTargets, sourceSetup.rendererType);
                 if (matchedTransform == null)
                 {
                     Debug.LogWarning($"[MA Material Helper] Could not find match for '{sourceSetup.objectName}'");
@@ -553,13 +553,13 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
             errorMessage = null;
             int totalMatchCount = 0;
             var limitationErrors = new List<string>();
-            var matchedPaths = new HashSet<string>();
+            var matchedTargets = new HashSet<Transform>();
 
             // Process each material setup in the group
             foreach (var sourceSetup in group)
             {
                 // Try to find matching object in target
-                var matchedTransform = ObjectMatcher.FindMatchingObject(targetRoot.transform, sourceSetup.objectName, sourceSetup.relativePath, sourceSetup.hierarchyDepth, sourceSetup.rootObjectName, matchedPaths, sourceSetup.rendererType);
+                var matchedTransform = ObjectMatcher.FindMatchingObject(targetRoot.transform, sourceSetup.objectName, sourceSetup.relativePath, sourceSetup.hierarchyDepth, sourceSetup.rootObjectName, matchedTargets, sourceSetup.rendererType);
                 if (matchedTransform == null)
                 {
                     Debug.LogWarning($"[MA Material Helper] Could not find match for '{sourceSetup.objectName}'");


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                        
  - #27 で追加した `matchedPaths`（重複マッチ防止の `HashSet<string>`）のキーが相対パス文字列だったため、`Transform.name` のみで構築される path が同名兄弟 GameObject 間で衝突し、2個目以降の兄弟がマッチ対象から消える silent なバグがあった           
  - 例: Target に `Body/Mesh` × 2 が存在し Source 側にも対応する2設定がある場合、1個目が target X を claim した時点で 2個目の source からは **X も Y も path 衝突で除外** されてしまい、`Could not find match for 'Mesh'`                               
  の警告だけが出てマテリアルが適用されなかった                                                                                                                                                                                                          
  - キーを `HashSet<Transform>` に変更し、Transform の参照 identity で区別するように修正。同名兄弟でも別オブジェクトとして正しく扱われるようになる                                                                                                      
                                                                                                                                                                                                                                                        
  ## 発生条件（3つ全部揃ったとき）                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                        
  1. Target 側の同じ親の下に、同じ名前の Renderer が2つ以上ある（FBX インポートで mesh 名が被るアバター等）                                                                                                                                             
  2. Source 側にも、それら同名兄弟に対応する設定が2つ以上ある
  3. トリガーは MA Material Helper の MaterialSetter / MaterialSwap 生成                                                                                                                                                                                
                                                                                                                                                                                                                                                        
  ※ 素の Material Copy/Paste は `matchedPaths` を使っていないため影響なし                                                                                                                                                                               
                                                                                                                                                                                                                                                        
  ## 既存動作への影響                                                                                                                                                                                                                                   
                                                        
  - マッチングロジック自体は無変更。影響するのは「claim 済み target の識別方法」だけ                                                                                                                                                                    
  - `ObjectMatcher.FindMatchingObject` のオプショナル引数 `matchedPaths` (`HashSet<string>`) が `matchedTargets` (`HashSet<Transform>`) にリネーム/型変更。外部からの利用は想定していないため実質 internal 扱い
  - 名前衝突のない衣装（大多数）では挙動に差分なし