### PR TITLE
fix: prevent deletion when dismissing confirmation dialog

### DIFF
--- a/Editor/ComponentManager.cs
+++ b/Editor/ComponentManager.cs
@@ -1460,7 +1460,7 @@ namespace Kanameliser.EditorPlus
                     }
                 }
 
-                confirmMessage += "\nThis action cannot be undone.";
+                confirmMessage += "\nUndo is available.";
                 return confirmMessage;
             }
             catch (Exception ex)
@@ -1486,12 +1486,12 @@ namespace Kanameliser.EditorPlus
                 bool confirmResult = EditorUtility.DisplayDialog(
                     "Confirm Deletion",
                     confirmMessage,
-                    "Cancel",
-                    "Delete"
+                    "Delete",
+                    "Cancel"
                 );
 
                 // ユーザーが「削除する」を選んだ場合のみ処理を実行
-                if (!confirmResult)
+                if (confirmResult)
                 {
                     // 処理を Undo でまとめる
                     Undo.SetCurrentGroupName("Remove GameObjects and Components");


### PR DESCRIPTION
## 概要
Component Manager のコンポーネント/GameObject 削除確認ダイアログで、
ボタンの割り当てが逆になっており、**キャンセルのつもりの操作で削除が実行される**

## 問題
`EditorUtility.DisplayDialog(title, msg, "Cancel", "Delete")` で "Delete" が cancel スロットに置かれ、`if (!confirmResult)` で削除していた。

- マウスで明示的にボタンを押す場合は偶然正しく動作
- しかし **Esc キー / ダイアログの × ボタンは cancel(=false)を返す**ため、「閉じる=キャンセル」のつもりで削除が実行されてしまう

あわせて確認メッセージの "This action cannot be undone." も誤りで、実際には Undo 可能なため文言を修正。

## 修正内容
- ボタン引数を `"Delete", "Cancel"`(OK スロット=Delete)の順に修正
- 削除実行条件を `if (confirmResult)` に反転
- メッセージを "Undo is available." に修正

## 動作確認
- [x] Esc / × ボタン → 削除されない
- [x] "Delete" クリック → 削除される
- [x] "Cancel" クリック → 削除されない
- [x] 削除後 Ctrl+Z で復元できる
- [x] Unity がコンパイルエラーなく再コンパイルされる

## 影響範囲
`Editor/ComponentManager.cs`(`RemoveSelectedComponents` / `CreateDeleteConfirmMessage`)のみ。
