### PR TITLE
fix: make component deletion resilient to individual failures

### DIFF
--- a/Editor/ComponentManager.cs
+++ b/Editor/ComponentManager.cs
@@ -1068,14 +1068,15 @@ namespace Kanameliser.EditorPlus
                 // オブジェクトフィールド
                 EditorGUI.BeginChangeCheck();
                 GameObject newTargetObject = EditorGUILayout.ObjectField("", targetObject, typeof(GameObject), true) as GameObject;
+                GameObject resultTargetObject = targetObject;
                 if (EditorGUI.EndChangeCheck() && newTargetObject != null)
                 {
                     dataManager.RefreshComponentsList(newTargetObject);
-                    return newTargetObject;
+                    resultTargetObject = newTargetObject;
                 }
 
                 EditorGUILayout.EndHorizontal();
-                return targetObject;
+                return resultTargetObject;
             }
             catch (Exception ex)
             {
@@ -1496,27 +1497,65 @@ namespace Kanameliser.EditorPlus
                     // 処理を Undo でまとめる
                     Undo.SetCurrentGroupName("Remove GameObjects and Components");
                     int undoGroup = Undo.GetCurrentGroup();
+                    List<string> failedItems = new List<string>();
 
-                    // 選択されたGameObjectを削除
-                    foreach (var gameObject in selectedGameObjects)
+                    try
                     {
-                        if (gameObject != null)
+                        // 選択されたGameObjectを削除
+                        foreach (var gameObject in selectedGameObjects)
                         {
-                            Undo.DestroyObjectImmediate(gameObject);
+                            if (gameObject == null) continue;
+
+                            string gameObjectName = gameObject.name;
+                            try
+                            {
+                                Undo.DestroyObjectImmediate(gameObject);
+                            }
+                            catch (Exception ex)
+                            {
+                                failedItems.Add($"GameObject: {gameObjectName}");
+                                Debug.LogWarning($"Failed to delete GameObject '{gameObjectName}': {ex.Message}");
+                            }
+                        }
+
+                        // 選択されたコンポーネントを削除
+                        foreach (var componentInfo in selectedComponents)
+                        {
+                            if (componentInfo == null || componentInfo.Component == null) continue;
+
+                            Component component = componentInfo.Component;
+                            string componentName = componentInfo.Name;
+                            try
+                            {
+                                Undo.DestroyObjectImmediate(component);
+                            }
+                            catch (Exception ex)
+                            {
+                                failedItems.Add($"Component: {componentName}");
+                                Debug.LogWarning($"Failed to delete component '{componentName}': {ex.Message}");
+                            }
+                        }
+                    }
+                    finally
+                    {
+                        try
+                        {
+                            Undo.CollapseUndoOperations(undoGroup);
+                        }
+                        finally
+                        {
+                            dataManager.RefreshComponentsList(targetObject);
                         }
                     }
 
-                    // 選択されたコンポーネントを削除
-                    foreach (var componentInfo in selectedComponents)
+                    if (failedItems.Count > 0)
                     {
-                        if (componentInfo != null && componentInfo.Component != null)
-                        {
-                            Undo.DestroyObjectImmediate(componentInfo.Component);
-                        }
+                        EditorUtility.DisplayDialog(
+                            "Deletion Partially Completed",
+                            $"Some selected items could not be deleted:\n\n{string.Join("\n", failedItems)}",
+                            "OK"
+                        );
                     }
-
-                    Undo.CollapseUndoOperations(undoGroup);
-                    dataManager.RefreshComponentsList(targetObject);
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## 概要
Component Manager の2件の不具合を修正

## 修正内容

### 1. ターゲット差し替え時の "Mismatched LayoutGroup" エラー
`DrawTargetObjectField` でターゲット変更時に `return` が `EndHorizontal()` を飛ばしており、`BeginHorizontal` と対応が取れず GUILayout エラーが発生していた。

- 戻り値を `resultTargetObject` 変数に保持し、必ず `EndHorizontal()` を通過してから return する構造に変更。

### 2. Prefabインスタンス上のコンポーネント削除失敗で残り全件が中断される
`Undo.DestroyObjectImmediate` は prefab インスタンスの一部に対して例外を投げる。
従来は全削除が単一 try/catch 内だったため、1件の失敗で残りの削除・`CollapseUndoOperations`・`RefreshComponentsList` がすべてスキップされていた。

- 各 destroy を**個別 try/catch** で包み、失敗しても残りを継続。
- 失敗アイテムを収集し、完了後に警告ダイアログでまとめて表示。
- `CollapseUndoOperations` + `RefreshComponentsList` は **`finally`** で必ず実行。

## 動作確認
- [x] ターゲットオブジェクトを差し替えても Console に GUILayout エラーが出ない
- [x] Prefabインスタンス上の削除不可コンポーネントを含む選択でも、残りは削除され、失敗分が警告ダイアログに表示される
- [x] 削除後 Ctrl+Z で復元できる
- [x] Unity がコンパイルエラーなく再コンパイルされる

## 影響範囲
`Editor/ComponentManager.cs`(`DrawTargetObjectField` / `RemoveSelectedComponents`)のみ。
