### PR TITLE
fix: harden material helper generation and hierarchy scanning

### DIFF
--- a/Editor/MAMaterialHelper/Common/MaterialSetupCopier.cs
+++ b/Editor/MAMaterialHelper/Common/MaterialSetupCopier.cs
@@ -8,7 +8,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
     /// </summary>
     public static class MaterialSetupCopier
     {
-        private const int MAX_HIERARCHY_DEPTH = 10;
+        private const int MAX_HIERARCHY_DEPTH = 32;
 
         /// <summary>
         /// Copies material setup from the specified GameObject and its children
@@ -24,7 +24,8 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
             };
 
             // Scan hierarchy and collect material data
-            ScanHierarchy(sourceRoot.transform, "", copiedData.materialSetups, 0, sourceRoot);
+            bool depthLimitWarningLogged = false;
+            ScanHierarchy(sourceRoot.transform, "", copiedData.materialSetups, 0, sourceRoot, ref depthLimitWarningLogged);
 
             return copiedData;
         }
@@ -32,10 +33,20 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
         /// <summary>
         /// Recursively scans the hierarchy for renderers and their materials
         /// </summary>
-        private static void ScanHierarchy(Transform current, string relativePath, List<MaterialSetupData> materialSetups, int depth, GameObject rootObject)
+        private static void ScanHierarchy(Transform current, string relativePath, List<MaterialSetupData> materialSetups, int depth, GameObject rootObject, ref bool depthLimitWarningLogged)
         {
             if (depth >= MAX_HIERARCHY_DEPTH)
+            {
+                if (!depthLimitWarningLogged)
+                {
+                    Debug.LogWarning(
+                        $"[MA Material Helper] Material setup scanning stopped at '{current.name}' because the hierarchy depth limit of {MAX_HIERARCHY_DEPTH} was reached. Renderers at or below this point were not copied.",
+                        rootObject
+                    );
+                    depthLimitWarningLogged = true;
+                }
                 return;
+            }
 
             // Build current relative path (without root name)
             string currentPath = string.IsNullOrEmpty(relativePath)
@@ -74,7 +85,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
                 Transform child = current.GetChild(i);
                 if (child != null)
                 {
-                    ScanHierarchy(child, currentPath, materialSetups, depth + 1, rootObject);
+                    ScanHierarchy(child, currentPath, materialSetups, depth + 1, rootObject, ref depthLimitWarningLogged);
                 }
             }
         }
@@ -125,7 +136,8 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
                 copiedData.materialSetups.Add(groupStartMarker);
 
                 // Scan hierarchy for this source root
-                ScanHierarchy(sourceRoot.transform, "", copiedData.materialSetups, 0, sourceRoot);
+                bool depthLimitWarningLogged = false;
+                ScanHierarchy(sourceRoot.transform, "", copiedData.materialSetups, 0, sourceRoot, ref depthLimitWarningLogged);
 
                 // Update source root name to include group info
                 if (i == 0)

--- a/Editor/MAMaterialHelper/MaterialSetter/MaterialSetterGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSetter/MaterialSetterGenerator.cs
@@ -75,13 +75,15 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSetter
                     // Clean up all created variations
                     foreach (var variation in createdVariations)
                     {
-                        UnityEngine.Object.DestroyImmediate(variation);
+                        Undo.DestroyObjectImmediate(variation);
                     }
 
                     if (isNewMenu)
                     {
-                        UnityEngine.Object.DestroyImmediate(colorMenu.gameObject);
+                        Undo.DestroyObjectImmediate(colorMenu.gameObject);
                     }
+
+                    Undo.CollapseUndoOperations(undoGroup);
 
                     return new GenerationResult
                     {

--- a/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
@@ -49,7 +49,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                 int totalSuccessfulMatches = 0;
                 int startingColorNumber = MAMaterialHelperUtils.DetermineNextColorNumber(colorMenu, COLOR_PREFIX);
                 string uniqueParameterName = ModularAvatarIntegration.DetermineParameterNameForColorMenu(colorMenu, targetRoot, MENU_ITEM_PARAMETER);
-                string limitationError = null;
+                var limitationErrors = new List<string>();
 
                 // Create color variations for each group
                 for (int groupIndex = 0; groupIndex < groups.Count; groupIndex++)
@@ -62,7 +62,11 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                     createdVariations.Add(colorVariation);
 
                     // Create material swaps for this group
-                    int groupMatches = SetupMaterialSwapsForGroup(colorVariation, targetRoot, group, out limitationError);
+                    int groupMatches = SetupMaterialSwapsForGroup(colorVariation, targetRoot, group, out string limitationError);
+                    if (!string.IsNullOrEmpty(limitationError))
+                    {
+                        limitationErrors.Add(limitationError);
+                    }
 
                     totalSuccessfulMatches += groupMatches;
 
@@ -77,13 +81,15 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                     // Clean up all created variations
                     foreach (var variation in createdVariations)
                     {
-                        UnityEngine.Object.DestroyImmediate(variation);
+                        Undo.DestroyObjectImmediate(variation);
                     }
 
                     if (isNewMenu)
                     {
-                        UnityEngine.Object.DestroyImmediate(colorMenu.gameObject);
+                        Undo.DestroyObjectImmediate(colorMenu.gameObject);
                     }
+
+                    Undo.CollapseUndoOperations(undoGroup);
 
                     return new GenerationResult
                     {
@@ -102,12 +108,12 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                     : $"Added {groups.Count} color variations (Color{startingColorNumber}-Color{startingColorNumber + groups.Count - 1})";
 
                 // If there were limitation errors, return them as warning
-                if (!string.IsNullOrEmpty(limitationError))
+                if (limitationErrors.Count > 0)
                 {
                     return new GenerationResult
                     {
                         success = false,
-                        message = limitationError,
+                        message = string.Join("\n\n", limitationErrors),
                         createdObject = createdVariations.Count > 0 ? createdVariations[0] : null
                     };
                 }
@@ -159,7 +165,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                 int totalSuccessfulMatches = 0;
                 int startingColorNumber = MAMaterialHelperUtils.DetermineNextColorNumber(colorMenu, COLOR_PREFIX);
                 string uniqueParameterName = ModularAvatarIntegration.DetermineParameterNameForColorMenu(colorMenu, targetRoot, MENU_ITEM_PARAMETER);
-                string limitationError = null;
+                var limitationErrors = new List<string>();
 
                 // Create color variations for each group
                 for (int groupIndex = 0; groupIndex < groups.Count; groupIndex++)
@@ -181,7 +187,11 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                     createdVariations.Add(colorVariation);
 
                     // Create material swaps for this group (per-object mode)
-                    int groupMatches = SetupMaterialSwapsPerObjectForGroup(colorVariation, targetRoot, group, out limitationError);
+                    int groupMatches = SetupMaterialSwapsPerObjectForGroup(colorVariation, targetRoot, group, out string limitationError);
+                    if (!string.IsNullOrEmpty(limitationError))
+                    {
+                        limitationErrors.Add(limitationError);
+                    }
 
                     totalSuccessfulMatches += groupMatches;
 
@@ -196,13 +206,15 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                     // Clean up all created variations
                     foreach (var variation in createdVariations)
                     {
-                        UnityEngine.Object.DestroyImmediate(variation);
+                        Undo.DestroyObjectImmediate(variation);
                     }
 
                     if (isNewMenu)
                     {
-                        UnityEngine.Object.DestroyImmediate(colorMenu.gameObject);
+                        Undo.DestroyObjectImmediate(colorMenu.gameObject);
                     }
+
+                    Undo.CollapseUndoOperations(undoGroup);
 
                     return new GenerationResult
                     {
@@ -221,12 +233,12 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                     : $"Added {groups.Count} color variations with per-object components";
 
                 // If there were limitation errors, return them as warning
-                if (!string.IsNullOrEmpty(limitationError))
+                if (limitationErrors.Count > 0)
                 {
                     return new GenerationResult
                     {
                         success = false,
-                        message = limitationError,
+                        message = string.Join("\n\n", limitationErrors),
                         createdObject = createdVariations.Count > 0 ? createdVariations[0] : null
                     };
                 }


### PR DESCRIPTION
## 概要
MA Material Helper の3件の不具合を修正

## 修正内容

### 1. 競合警告が後続グループで上書きされ消える
`CreateMaterialSwap` / `CreateMaterialSwapPerObject` で、グループごとに`out limitationError` を毎回受けていたため、グループ1で Material Swap 制限 (同一マテリアル→複数マテリアルの競合) を検出しても、後続グループに競合がなければ警告が上書きされて消え、無警告で壊れた結果が残っていた。

- エラーを `List<string>` に蓄積し、ループ後に `string.Join` してまとめて返すよう変更。

### 2. マッチ0件時のクリーンアップが Undo 非対応だった
生成オブジェクトは `Undo.RegisterCreatedObjectUndo` 済みなのに、失敗時の掃除が素の `DestroyImmediate` で行われ、破棄済みオブジェクトを指す Undo レコードがスタックに残り、その後の Ctrl+Z で不正な巻き戻しが起きうる状態だった。

- クリーンアップを `Undo.DestroyObjectImmediate` に置換し、失敗パスでも `Undo.CollapseUndoOperations` を呼んで整合させる。
- 対象: MaterialSetterGenerator / MaterialSwapGenerator(通常・per-object 両方)

### 3. MaterialSetupCopier の深さ制限10で深い階層が漏れる
`ScanHierarchy` が `MAX_HIERARCHY_DEPTH = 10` で警告なく打ち切っており、VRChat アバターのボーン下メッシュ(Armature/Hips/Spine/...)が10段を超えると該当レンダラーだけ静かに欠落していた。

- 上限を `32` に引き上げ。
- 打ち切り発生時に `Debug.LogWarning` を出力(`ref` フラグで1回だけ警告し、
  単一ソース・複数ソース両方に適用)。

## 動作確認
- [x] 複数グループで先頭グループのみ競合がある場合に警告が表示される
- [x] マッチ0件時に Ctrl+Z してもエラーが出ず、オブジェクトが残らない
- [x] 10段を超える階層のメッシュもコピー対象になり、必要時に警告が出る
- [x] Unity がコンパイルエラーなく再コンパイルされる

## 影響範囲
- `Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs`
- `Editor/MAMaterialHelper/MaterialSetter/MaterialSetterGenerator.cs`
- `Editor/MAMaterialHelper/Common/MaterialSetupCopier.cs`
- `Editor/MAMaterialHelper/MAMaterialHelperEditor.cs`
