### PR TITLE
fix: prevent duplicate mesh material slot counts

### DIFF
--- a/Editor/MeshInfo/MeshInfoCalculator.cs
+++ b/Editor/MeshInfo/MeshInfoCalculator.cs
@@ -10,12 +10,13 @@ namespace Kanameliser.EditorPlus
             var data = new MeshInfoData();
             var processedMeshes = new HashSet<Mesh>();
             var processedMaterials = new HashSet<Material>();
+            var processedRenderers = new HashSet<Renderer>();
             bool hasChildObjects = false;
             int materialSlots = 0;
 
             foreach (var obj in gameObjects)
             {
-                data.Triangles += ProcessGameObject(obj, processedMeshes, processedMaterials, ref hasChildObjects, ref materialSlots);
+                data.Triangles += ProcessGameObject(obj, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref materialSlots);
             }
 
             data.Meshes = processedMeshes.Count;
@@ -26,7 +27,7 @@ namespace Kanameliser.EditorPlus
             return data;
         }
 
-        private int ProcessGameObject(GameObject obj, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials,
+        private int ProcessGameObject(GameObject obj, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials, HashSet<Renderer> processedRenderers,
             ref bool hasChildObjects, ref int totalMaterialSlots)
         {
             // Skip objects tagged as EditorOnly as they won't be included in builds
@@ -39,11 +40,11 @@ namespace Kanameliser.EditorPlus
 
             int triangleCount = 0;
 
-            triangleCount += MeshInfoUtility.ProcessStandardMeshComponents(obj, processedMeshes, processedMaterials, ref totalMaterialSlots);
+            triangleCount += MeshInfoUtility.ProcessStandardMeshComponents(obj, processedMeshes, processedMaterials, processedRenderers, ref totalMaterialSlots);
 
             foreach (Transform child in obj.transform)
             {
-                triangleCount += ProcessGameObject(child.gameObject, processedMeshes, processedMaterials, ref hasChildObjects, ref totalMaterialSlots);
+                triangleCount += ProcessGameObject(child.gameObject, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref totalMaterialSlots);
             }
 
             return triangleCount;

--- a/Editor/MeshInfo/MeshInfoNDMFIntegration.cs
+++ b/Editor/MeshInfo/MeshInfoNDMFIntegration.cs
@@ -37,12 +37,13 @@ namespace Kanameliser.EditorPlus
             var data = new MeshInfoData();
             var processedMeshes = new HashSet<Mesh>();
             var processedMaterials = new HashSet<Material>();
+            var processedRenderers = new HashSet<Renderer>();
             bool hasChildObjects = false;
             int materialSlots = 0;
 
             foreach (var obj in gameObjects)
             {
-                data.Triangles += ProcessGameObjectWithProxy(obj, processedMeshes, processedMaterials, ref hasChildObjects, ref materialSlots);
+                data.Triangles += ProcessGameObjectWithProxy(obj, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref materialSlots);
             }
 
             data.Meshes = processedMeshes.Count;
@@ -53,7 +54,7 @@ namespace Kanameliser.EditorPlus
             return data;
         }
 
-        private int ProcessGameObjectWithProxy(GameObject obj, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials,
+        private int ProcessGameObjectWithProxy(GameObject obj, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials, HashSet<Renderer> processedRenderers,
             ref bool hasChildObjects, ref int totalMaterialSlots)
         {
             if (obj.CompareTag("EditorOnly"))
@@ -73,30 +74,30 @@ namespace Kanameliser.EditorPlus
                 {
                     // Use proxy mesh data instead of original for accurate build preview
                     IsShowingProxyInfo = true;
-                    triangleCount = ProcessProxyRenderer(proxyRenderer, processedMeshes, processedMaterials, ref totalMaterialSlots);
+                    triangleCount = ProcessProxyRenderer(proxyRenderer, processedMeshes, processedMaterials, processedRenderers, ref totalMaterialSlots);
 
                     foreach (Transform child in obj.transform)
                     {
-                        triangleCount += ProcessGameObjectWithProxy(child.gameObject, processedMeshes, processedMaterials, ref hasChildObjects, ref totalMaterialSlots);
+                        triangleCount += ProcessGameObjectWithProxy(child.gameObject, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref totalMaterialSlots);
                     }
 
                     return triangleCount;
                 }
             }
 
-            triangleCount += MeshInfoUtility.ProcessStandardMeshComponents(obj, processedMeshes, processedMaterials, ref totalMaterialSlots);
+            triangleCount += MeshInfoUtility.ProcessStandardMeshComponents(obj, processedMeshes, processedMaterials, processedRenderers, ref totalMaterialSlots);
 
             foreach (Transform child in obj.transform)
             {
-                triangleCount += ProcessGameObjectWithProxy(child.gameObject, processedMeshes, processedMaterials, ref hasChildObjects, ref totalMaterialSlots);
+                triangleCount += ProcessGameObjectWithProxy(child.gameObject, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref totalMaterialSlots);
             }
 
             return triangleCount;
         }
 
-        private int ProcessProxyRenderer(Renderer proxyRenderer, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials, ref int totalMaterialSlots)
+        private int ProcessProxyRenderer(Renderer proxyRenderer, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials, HashSet<Renderer> processedRenderers, ref int totalMaterialSlots)
         {
-            return MeshInfoUtility.ProcessStandardMeshComponents(proxyRenderer.gameObject, processedMeshes, processedMaterials, ref totalMaterialSlots);
+            return MeshInfoUtility.ProcessStandardMeshComponents(proxyRenderer.gameObject, processedMeshes, processedMaterials, processedRenderers, ref totalMaterialSlots);
         }
 
     }

--- a/Editor/MeshInfo/MeshInfoUtility.cs
+++ b/Editor/MeshInfo/MeshInfoUtility.cs
@@ -34,7 +34,7 @@ namespace Kanameliser.EditorPlus
             }
         }
 
-        public static int ProcessStandardMeshComponents(GameObject obj, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials, ref int totalMaterialSlots)
+        public static int ProcessStandardMeshComponents(GameObject obj, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials, HashSet<Renderer> processedRenderers, ref int totalMaterialSlots)
         {
             int triangleCount = 0;
 
@@ -46,7 +46,7 @@ namespace Kanameliser.EditorPlus
             {
                 triangleCount += ProcessMesh(meshFilter.sharedMesh, processedMeshes);
 
-                if (meshRenderer != null && meshRenderer.sharedMaterials != null)
+                if (meshRenderer != null && meshRenderer.sharedMaterials != null && processedRenderers.Add(meshRenderer))
                 {
                     ProcessMaterials(meshRenderer.sharedMaterials, processedMaterials);
                     totalMaterialSlots += meshRenderer.sharedMaterials.Length;
@@ -59,7 +59,7 @@ namespace Kanameliser.EditorPlus
             {
                 triangleCount += ProcessMesh(skinnedMeshRenderer.sharedMesh, processedMeshes);
 
-                if (skinnedMeshRenderer.sharedMaterials != null)
+                if (skinnedMeshRenderer.sharedMaterials != null && processedRenderers.Add(skinnedMeshRenderer))
                 {
                     ProcessMaterials(skinnedMeshRenderer.sharedMaterials, processedMaterials);
                     totalMaterialSlots += skinnedMeshRenderer.sharedMaterials.Length;


### PR DESCRIPTION
## 概要
MeshInfo で親と子を同時選択したときに Material Slots が水増しされる不具合を修正

## 問題
親と子を同時選択すると、親の再帰処理と子自身の処理で同じ Renderer が2回処理される。Triangles / Materials は HashSet で重複排除されるが、`totalMaterialSlots +=` だけ無条件加算だったため、Material Slots のみが二重カウントされ、他の指標と食い違っていた。

## 修正内容
- `ProcessStandardMeshComponents` に `HashSet<Renderer> processedRenderers` を追加し、`totalMaterialSlots +=` を `processedRenderers.Add(renderer)` でガード。
- 呼び出し側(通常計算・NDMF 統合の両方)で `processedRenderers` を選択オブジェクトのループ前に1個だけ生成し、再帰・プロキシ経路を通して持ち回り。

これにより Triangles(Mesh単位)/ Materials(Material単位)/Material Slots(Renderer単位)が同じ重複排除ロジックで揃う。

## 動作確認
- [x] 親+子を同時選択した Material Slots が、子を単独選択した時の合計と一致する
- [x] NDMF 統合経路でも同様に二重カウントされない
- [x] Unity がコンパイルエラーなく再コンパイルされる

## 影響範囲
- `Editor/MeshInfo/MeshInfoUtility.cs`
- `Editor/MeshInfo/MeshInfoCalculator.cs`
- `Editor/MeshInfo/MeshInfoNDMFIntegration.cs`
