### PR TITLE
fix: harden AO bounds setter interactions

### DIFF
--- a/Editor/AOBoundsSetter/AOBoundsSetterWindow.cs
+++ b/Editor/AOBoundsSetter/AOBoundsSetterWindow.cs
@@ -307,8 +307,11 @@ namespace Kanameliser.EditorPlus
             nameContainer.AddToClassList("clickable-label");
             nameContainer.RegisterCallback<MouseDownEvent>(evt =>
             {
-                Selection.activeGameObject = data.Renderer.gameObject;
-                EditorGUIUtility.PingObject(data.Renderer.gameObject);
+                var renderer = data.Renderer;
+                if (renderer == null) return;
+
+                Selection.activeGameObject = renderer.gameObject;
+                EditorGUIUtility.PingObject(renderer.gameObject);
             });
 
             var iconContent = EditorGUIUtility.ObjectContent(data.Renderer, data.Renderer.GetType());
@@ -331,11 +334,11 @@ namespace Kanameliser.EditorPlus
             aoLabel.AddToClassList("clickable-label");
             aoLabel.RegisterCallback<MouseDownEvent>(evt =>
             {
-                if (data.Renderer.probeAnchor != null)
-                {
-                    Selection.activeGameObject = data.Renderer.probeAnchor.gameObject;
-                    EditorGUIUtility.PingObject(data.Renderer.probeAnchor.gameObject);
-                }
+                var renderer = data.Renderer;
+                if (renderer == null || renderer.probeAnchor == null) return;
+
+                Selection.activeGameObject = renderer.probeAnchor.gameObject;
+                EditorGUIUtility.PingObject(renderer.probeAnchor.gameObject);
             });
             row.Add(aoLabel);
 
@@ -345,11 +348,11 @@ namespace Kanameliser.EditorPlus
             rootBoneLabel.AddToClassList("clickable-label");
             rootBoneLabel.RegisterCallback<MouseDownEvent>(evt =>
             {
-                if (data.Renderer is SkinnedMeshRenderer smr && smr.rootBone != null)
-                {
-                    Selection.activeGameObject = smr.rootBone.gameObject;
-                    EditorGUIUtility.PingObject(smr.rootBone.gameObject);
-                }
+                var skinnedMeshRenderer = data.Renderer as SkinnedMeshRenderer;
+                if (skinnedMeshRenderer == null || skinnedMeshRenderer.rootBone == null) return;
+
+                Selection.activeGameObject = skinnedMeshRenderer.rootBone.gameObject;
+                EditorGUIUtility.PingObject(skinnedMeshRenderer.rootBone.gameObject);
             });
             row.Add(rootBoneLabel);
 
@@ -479,13 +482,13 @@ namespace Kanameliser.EditorPlus
         private void OnApplyButtonClicked()
         {
             var selectedRenderers = meshRendererDataList
-                .Where(d => d.IsSelected)
+                .Where(d => d.IsSelected && d.Renderer != null)
                 .Select(d => d.Renderer)
                 .ToArray();
 
             if (selectedRenderers.Length == 0)
             {
-                Debug.LogWarning("No meshes selected.");
+                Debug.LogWarning("No valid meshes selected.");
                 return;
             }
 
@@ -505,6 +508,8 @@ namespace Kanameliser.EditorPlus
 
             foreach (var renderer in selectedRenderers)
             {
+                if (renderer == null) continue;
+
                 // Apply Anchor Override
                 if (anchorOverride != null || renderer.probeAnchor != null)
                 {

--- a/Editor/AOBoundsSetter/TransformSelectorWindow.cs
+++ b/Editor/AOBoundsSetter/TransformSelectorWindow.cs
@@ -51,6 +51,7 @@ namespace Kanameliser.EditorPlus
 
             window.position = new Rect(screenPosition, windowSize);
             window.ShowPopup();
+            window.Focus();
         }
 
         public void CreateGUI()
@@ -213,6 +214,15 @@ namespace Kanameliser.EditorPlus
         {
             // Close window when it loses focus
             Close();
+        }
+
+        private void OnGUI()
+        {
+            if (Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Escape)
+            {
+                Close();
+                Event.current.Use();
+            }
         }
     }
 }


### PR DESCRIPTION
## 概要
AOBoundsSetter の2件の不具合を修正

## 修正内容

### 1. 破棄済み Renderer 参照で Apply が部分失敗・中断する
リスト構築後に対象オブジェクトが削除されると、Apply 時の `Undo.RecordObjects` /`renderer.probeAnchor` で MissingReferenceException が発生し、途中で中断していた。
行クリックのコールバックも同様。

- Apply 前に `meshRendererDataList.Where(d => d.IsSelected && d.Renderer != null)`でフィルタ(Unity の fake-null 判定)。
- 行クリック(名前 / Anchor Override / Root Bone)のコールバックにも null チェックを追加。

### 2. フォーカスなしの ShowPopup で閉じられない孤児ウィンドウが残る
`ShowPopup()` はフォーカスを与えないため、一度もクリックしないまま他所をクリックすると`OnLostFocus` が発火せず、閉じるボタンのないウィンドウが残留していた。

- `ShowPopup()` 直後に `window.Focus()` を呼び、`OnLostFocus` が確実に発火するようにする。
- `OnGUI` に Escape キーで `Close()` する処理を追加。

## 動作確認
- [x] TransformSelector ポップアップを開いて他所クリック → 閉じる / Esc → 閉じる
- [x] リスト表示中に対象を削除しても、Apply で残りが適用され例外で中断しない
- [x] 同状態で行(名前 / AO / Root Bone)をクリックしてもエラーが出ない
- [x] Unity がコンパイルエラーなく再コンパイルされる

## 影響範囲
- `Editor/AOBoundsSetter/AOBoundsSetterWindow.cs`
- `Editor/AOBoundsSetter/TransformSelectorWindow.cs`
