### PR TITLE
fix: harden missing blend shape clip handling

### DIFF
--- a/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterConfirmationWindow.cs
+++ b/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterConfirmationWindow.cs
@@ -364,16 +364,22 @@ namespace Kanameliser.EditorPlus
         private bool IsClipReadOnly(AnimationClip clip)
         {
             string assetPath = AssetDatabase.GetAssetPath(clip);
+            if (string.IsNullOrEmpty(assetPath) ||
+                !string.Equals(Path.GetExtension(assetPath), ".anim", System.StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
             string fullPath = Path.GetFullPath(assetPath);
 
-            return (File.GetAttributes(fullPath) & FileAttributes.ReadOnly) != 0;
+            return !File.Exists(fullPath) || (File.GetAttributes(fullPath) & FileAttributes.ReadOnly) != 0;
         }
 
         // 読み取り専用エラーの表示
         private void ShowReadOnlyError(AnimationClip clip)
         {
             string assetPath = AssetDatabase.GetAssetPath(clip);
-            EditorUtility.DisplayDialog("エラー", $"ファイルが読み取り専用のため、上書きできません。ファイルパス: {assetPath}", "OK");
+            EditorUtility.DisplayDialog("エラー", $"ファイルが読み取り専用、または .anim ファイルではないため、上書きできません。ファイルパス: {assetPath}", "OK");
         }
 
         // 新しいクリップの作成

--- a/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterWindow.cs
+++ b/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterWindow.cs
@@ -133,16 +133,25 @@ namespace Kanameliser.EditorPlus
             scrollPos = EditorGUILayout.BeginScrollView(scrollPos, GUILayout.Height(listHeight + 10f));
 
             // 各アニメーションクリップを描画
+            int clipIndexToRemove = -1;
             for (int i = 0; i < animationClips.Count; i++)
             {
-                DrawAnimationClipItem(i);
+                if (DrawAnimationClipItem(i))
+                {
+                    clipIndexToRemove = i;
+                }
             }
 
             EditorGUILayout.EndScrollView(); // スクロールビューの終了
+
+            if (clipIndexToRemove >= 0)
+            {
+                animationClips.RemoveAt(clipIndexToRemove);
+            }
         }
 
         // 個々のアニメーションクリップアイテムの描画
-        private void DrawAnimationClipItem(int index)
+        private bool DrawAnimationClipItem(int index)
         {
             EditorGUILayout.BeginHorizontal(); // 水平レイアウトの開始
 
@@ -155,17 +164,20 @@ namespace Kanameliser.EditorPlus
                 UpdateAnimationClipAt(index, newClip);
 
             // 削除ボタン
-            if (GUILayout.Button("-", GUILayout.Width(30)))
-            {
-                animationClips.RemoveAt(index);
-                return;
-            }
+            bool shouldRemove = GUILayout.Button("-", GUILayout.Width(30));
 
             EditorGUILayout.EndHorizontal(); // 水平レイアウトの終了
+
+            if (shouldRemove)
+            {
+                return true;
+            }
 
             // 直前に描画した領域を取得し、ドラッグ＆ドロップ処理を設定
             Rect lastRect = GUILayoutUtility.GetLastRect();
             HandleDragAndDropOnItem(lastRect, index);
+
+            return false;
         }
 
         // アニメーションクリップの更新と重複チェック


### PR DESCRIPTION
## 概要
MissingBlendShapeInserter の2件の不具合を修正

## 修正内容

### 1. "-" ボタンの early return でレイアウトが不整合になる
`BeginHorizontal` と `EndHorizontal` の間で `RemoveAt + return` しており、クリックのたびに GUILayout エラーが出ていた。

- `DrawAnimationClipItem` はクリックを bool で返し、必ず `EndHorizontal()` を通過してから return する構造に変更。
- 削除対象 index をループ外変数に記録し、ループ終了(`EndScrollView` 通過後)に`RemoveAt` を実行。

### 2. FBX埋め込みクリップへの上書きが黙って消える
`IsClipReadOnly` がファイル属性の ReadOnly しか見ておらず、FBX 等インポートアセット内の AnimationClip がチェックを通過していた。`SetEditorCurve` はメモリ上では成功し完了ダイアログまで出るが、永続化されず再インポートで消失する。

- `AssetDatabase.GetAssetPath(clip)` が空、または拡張子が `.anim` でない場合は読み取り専用(上書き不可)と判定。
- エラーダイアログの文言も「.anim ファイルではない」ケースを含むよう更新。

## 動作確認
- [x] クリップ一覧の "-" ボタンで GUILayout エラーが出ない
- [x] FBX 内クリップを上書き対象にするとエラーが表示される
- [x] 通常の .anim クリップは従来どおり上書きできる
- [x] Unity がコンパイルエラーなく再コンパイルされる

## 影響範囲
- `Editor/MissingBlendShapeInserter/MissingBlendShapeInserterWindow.cs`
- `Editor/MissingBlendShapeInserter/MissingBlendShapeInserterConfirmationWindow.cs`
