### PR TITLE
fix: stabilize material swap limitation slot order

### DIFF
--- a/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
@@ -342,7 +342,9 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                     if (uniqueTargets.Count > 1)
                     {
                         hasConflict = true;
-                        var slotInfo = string.Join(", ", targets.Select(t => $"Slot{t.slotIndex}→{t.targetMaterial.name}"));
+                        var slotInfo = string.Join(", ", targets
+                            .OrderBy(t => t.slotIndex)
+                            .Select(t => $"Slot{t.slotIndex}→{t.targetMaterial.name}"));
                         conflictDetails.Add($"  - '{obj.name}': {slotInfo}");
                     }
                 }


### PR DESCRIPTION
## 概要

`HasSameObjectMultipleTargets` メソッドが出力する競合詳細メッセージにおいて、スロットの並び順が不定だった問題を修正。

`OrderBy(t => t.slotIndex)` を追加し、スロットインデックス昇順でソートされた状態でメッセージを生成するようにした。

## 変更内容

- `MaterialSwapGenerator.cs` — 競合スロット情報の表示時に `slotIndex` でソートを追加

## 動作確認

- 同一オブジェクトに複数スロットのスワップが設定されている場合、エラーメッセージのスロット順が毎回同じになる
