### PR TITLE
refactor: consolidate MA generation core into shared utilities

### DIFF
--- a/Editor/MAMaterialHelper/Common/MAMaterialHelperUtils.cs
+++ b/Editor/MAMaterialHelper/Common/MAMaterialHelperUtils.cs
@@ -44,8 +44,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
                 message = "Modular Avatar is not installed"
             };
             return false;
-#endif
-
+#else
             if (targetRoot == null || copiedData == null)
             {
                 result = new GenerationResult
@@ -58,6 +57,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
 
             result = default;
             return true;
+#endif
         }
 
         /// <summary>

--- a/Editor/MAMaterialHelper/Common/MAMaterialHelperUtils.cs
+++ b/Editor/MAMaterialHelper/Common/MAMaterialHelperUtils.cs
@@ -10,6 +10,8 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
     /// </summary>
     public static class MAMaterialHelperUtils
     {
+        internal const string ColorMenuName = "Color Menu";
+
         /// <summary>
         /// Validates if all requirements are met for MA Material Helper functionality
         /// </summary>
@@ -28,6 +30,51 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
                 message = "All requirements met"
             };
 #endif
+        }
+
+        /// <summary>
+        /// Validates input parameters for MA generation
+        /// </summary>
+        internal static bool ValidateGenerationParameters(GameObject targetRoot, CopiedMaterialData copiedData, out GenerationResult result)
+        {
+#if !MODULAR_AVATAR_INSTALLED
+            result = new GenerationResult
+            {
+                success = false,
+                message = "Modular Avatar is not installed"
+            };
+            return false;
+#endif
+
+            if (targetRoot == null || copiedData == null)
+            {
+                result = new GenerationResult
+                {
+                    success = false,
+                    message = "Invalid parameters"
+                };
+                return false;
+            }
+
+            result = default;
+            return true;
+        }
+
+        /// <summary>
+        /// Ensures Color Menu exists and returns it with creation status
+        /// </summary>
+        internal static (Transform colorMenu, bool isNewMenu) EnsureColorMenu(GameObject targetRoot)
+        {
+            Transform colorMenu = targetRoot.transform.Find(ColorMenuName);
+            bool isNewMenu = colorMenu == null;
+
+            if (isNewMenu)
+            {
+                var colorMenuObj = ModularAvatarIntegration.CreateColorMenu(targetRoot, ColorMenuName);
+                colorMenu = colorMenuObj.transform;
+            }
+
+            return (colorMenu, isNewMenu);
         }
 
         /// <summary>

--- a/Editor/MAMaterialHelper/Common/ModularAvatarIntegration.cs
+++ b/Editor/MAMaterialHelper/Common/ModularAvatarIntegration.cs
@@ -239,27 +239,6 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
         }
 
         /// <summary>
-        /// Creates a color variation GameObject with Material Swap components
-        /// </summary>
-        public static GameObject CreateColorVariation(Transform parent, string name, int colorNumber, string gameObjectName, string parameterName)
-        {
-            var colorVariation = new GameObject(name);
-            colorVariation.transform.SetParent(parent, false);
-
-            // Register the created GameObject with Undo system
-            Undo.RegisterCreatedObjectUndo(colorVariation, "Create Color Variation");
-
-            // Add Material Swap component
-            var materialSwap = Undo.AddComponent<ModularAvatarMaterialSwap>(colorVariation);
-
-            // Add Menu Item component
-            var menuItem = Undo.AddComponent<ModularAvatarMenuItem>(colorVariation);
-            ConfigureMenuItemAsToggle(menuItem, name, colorNumber, gameObjectName, parameterName);
-
-            return colorVariation;
-        }
-
-        /// <summary>
         /// Sets up the Material Swap component
         /// </summary>
         public static void SetupMaterialSwap(GameObject swapObject, GameObject rootObject, List<(Material from, Material to)> swaps)
@@ -308,11 +287,6 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
         }
 
         public static GameObject CreateMenuToggleVariation(Transform parent, string name, int colorNumber, string gameObjectName, string parameterName)
-        {
-            throw new InvalidOperationException("Modular Avatar is not available");
-        }
-
-        public static GameObject CreateColorVariation(Transform parent, string name, int colorNumber, string gameObjectName, string parameterName)
         {
             throw new InvalidOperationException("Modular Avatar is not available");
         }

--- a/Editor/MAMaterialHelper/Common/ModularAvatarIntegration.cs
+++ b/Editor/MAMaterialHelper/Common/ModularAvatarIntegration.cs
@@ -221,6 +221,24 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
         }
 
         /// <summary>
+        /// Creates a color variation GameObject with a Menu Item toggle only
+        /// </summary>
+        public static GameObject CreateMenuToggleVariation(Transform parent, string name, int colorNumber, string gameObjectName, string parameterName)
+        {
+            var colorVariation = new GameObject(name);
+            colorVariation.transform.SetParent(parent, false);
+
+            // Register the created GameObject with Undo system
+            Undo.RegisterCreatedObjectUndo(colorVariation, "Create Color Variation");
+
+            // Add Menu Item component
+            var menuItem = Undo.AddComponent<ModularAvatarMenuItem>(colorVariation);
+            ConfigureMenuItemAsToggle(menuItem, name, colorNumber, gameObjectName, parameterName);
+
+            return colorVariation;
+        }
+
+        /// <summary>
         /// Creates a color variation GameObject with Material Swap components
         /// </summary>
         public static GameObject CreateColorVariation(Transform parent, string name, int colorNumber, string gameObjectName, string parameterName)
@@ -285,6 +303,11 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
         }
 #else
         public static GameObject CreateColorMenu(GameObject parent, string menuName)
+        {
+            throw new InvalidOperationException("Modular Avatar is not available");
+        }
+
+        public static GameObject CreateMenuToggleVariation(Transform parent, string name, int colorNumber, string gameObjectName, string parameterName)
         {
             throw new InvalidOperationException("Modular Avatar is not available");
         }

--- a/Editor/MAMaterialHelper/MaterialSetter/MaterialSetterGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSetter/MaterialSetterGenerator.cs
@@ -57,7 +57,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSetter
                     int colorNumber = startingColorNumber + groupIndex;
                     string colorName = $"{COLOR_PREFIX}{colorNumber}";
 
-                    var colorVariation = CreateColorVariation(colorMenu, colorName, colorNumber, targetRoot.name, uniqueParameterName);
+                    var colorVariation = ModularAvatarIntegration.CreateMenuToggleVariation(colorMenu, colorName, colorNumber, targetRoot.name, uniqueParameterName);
                     createdVariations.Add(colorVariation);
 
                     // Create material setters for this group
@@ -165,27 +165,6 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSetter
             return (colorMenu, isNewMenu);
         }
 
-        /// <summary>
-        /// Creates a color variation GameObject with components
-        /// </summary>
-        private static GameObject CreateColorVariation(Transform parent, string name, int colorNumber, string gameObjectName, string parameterName)
-        {
-#if MODULAR_AVATAR_INSTALLED
-            var colorVariation = new GameObject(name);
-            colorVariation.transform.SetParent(parent, false);
-
-            Undo.RegisterCreatedObjectUndo(colorVariation, "Create Color Variation");
-
-            var menuItem = Undo.AddComponent<ModularAvatarMenuItem>(colorVariation);
-            ModularAvatarIntegration.ConfigureMenuItemAsToggle(menuItem, name, colorNumber, gameObjectName, parameterName);
-
-            return colorVariation;
-#else
-            throw new InvalidOperationException("Modular Avatar is not installed");
-#endif
-        }
-
-        /// <summary>
         /// Sets up material setters for a specific group
         /// </summary>
         private static int SetupMaterialSettersForGroup(GameObject colorVariation, GameObject targetRoot, List<MaterialSetupData> group, bool skipUnchanged)

--- a/Editor/MAMaterialHelper/MaterialSetter/MaterialSetterGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSetter/MaterialSetterGenerator.cs
@@ -14,7 +14,6 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSetter
     /// </summary>
     public static class MaterialSetterGenerator
     {
-        private const string COLOR_MENU_NAME = "Color Menu";
         private const string COLOR_PREFIX = "Color";
         public const string MENU_ITEM_PARAMETER = "KEP/MaterialSetter";
 
@@ -24,7 +23,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSetter
         /// <param name="skipUnchanged">If true, only creates setters for materials that differ from current materials</param>
         public static GenerationResult CreateMaterialSetter(GameObject targetRoot, CopiedMaterialData copiedData, bool skipUnchanged = true)
         {
-            if (!ValidateParameters(targetRoot, copiedData, out var validationResult))
+            if (!MAMaterialHelperUtils.ValidateGenerationParameters(targetRoot, copiedData, out var validationResult))
                 return validationResult;
 
             try
@@ -33,7 +32,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSetter
                 Undo.SetCurrentGroupName("Create Material Setter");
                 int undoGroup = Undo.GetCurrentGroup();
 
-                var (colorMenu, isNewMenu) = EnsureColorMenu(targetRoot);
+                var (colorMenu, isNewMenu) = MAMaterialHelperUtils.EnsureColorMenu(targetRoot);
                 var groups = MAMaterialHelperSession.GetCopiedDataGroups();
 
                 if (groups.Count == 0)
@@ -121,50 +120,6 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSetter
         #region Private Methods
 
         /// <summary>
-        /// Validates input parameters for material setter generation
-        /// </summary>
-        private static bool ValidateParameters(GameObject targetRoot, CopiedMaterialData copiedData, out GenerationResult result)
-        {
-#if !MODULAR_AVATAR_INSTALLED
-            result = new GenerationResult
-            {
-                success = false,
-                message = "Modular Avatar is not installed"
-            };
-            return false;
-#endif
-
-            if (targetRoot == null || copiedData == null)
-            {
-                result = new GenerationResult
-                {
-                    success = false,
-                    message = "Invalid parameters"
-                };
-                return false;
-            }
-
-            result = default;
-            return true;
-        }
-
-        /// <summary>
-        /// Ensures Color Menu exists and returns it with creation status
-        /// </summary>
-        private static (Transform colorMenu, bool isNewMenu) EnsureColorMenu(GameObject targetRoot)
-        {
-            Transform colorMenu = targetRoot.transform.Find(COLOR_MENU_NAME);
-            bool isNewMenu = colorMenu == null;
-
-            if (isNewMenu)
-            {
-                var colorMenuObj = ModularAvatarIntegration.CreateColorMenu(targetRoot, COLOR_MENU_NAME);
-                colorMenu = colorMenuObj.transform;
-            }
-
-            return (colorMenu, isNewMenu);
-        }
-
         /// Sets up material setters for a specific group
         /// </summary>
         private static int SetupMaterialSettersForGroup(GameObject colorVariation, GameObject targetRoot, List<MaterialSetupData> group, bool skipUnchanged)

--- a/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
@@ -58,7 +58,10 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                     int colorNumber = startingColorNumber + groupIndex;
                     string colorName = $"{COLOR_PREFIX}{colorNumber}";
 
-                    var colorVariation = ModularAvatarIntegration.CreateColorVariation(colorMenu, colorName, colorNumber, targetRoot.name, uniqueParameterName);
+                    var colorVariation = ModularAvatarIntegration.CreateMenuToggleVariation(colorMenu, colorName, colorNumber, targetRoot.name, uniqueParameterName);
+#if MODULAR_AVATAR_INSTALLED
+                    Undo.AddComponent<ModularAvatarMaterialSwap>(colorVariation);
+#endif
                     createdVariations.Add(colorVariation);
 
                     // Create material swaps for this group
@@ -174,16 +177,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                     int colorNumber = startingColorNumber + groupIndex;
                     string colorName = $"{COLOR_PREFIX}{colorNumber}";
 
-                    var colorVariation = new GameObject(colorName);
-                    colorVariation.transform.SetParent(colorMenu, false);
-
-                    // Register the created GameObject with Undo system
-                    Undo.RegisterCreatedObjectUndo(colorVariation, "Create Color Variation");
-
-#if MODULAR_AVATAR_INSTALLED
-                    var menuItem = Undo.AddComponent<ModularAvatarMenuItem>(colorVariation);
-                    ModularAvatarIntegration.ConfigureMenuItemAsToggle(menuItem, colorName, colorNumber, targetRoot.name, uniqueParameterName);
-#endif
+                    var colorVariation = ModularAvatarIntegration.CreateMenuToggleVariation(colorMenu, colorName, colorNumber, targetRoot.name, uniqueParameterName);
                     createdVariations.Add(colorVariation);
 
                     // Create material swaps for this group (per-object mode)

--- a/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
@@ -15,7 +15,6 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
     /// </summary>
     public static class MaterialSwapGenerator
     {
-        private const string COLOR_MENU_NAME = "Color Menu";
         private const string COLOR_PREFIX = "Color";
         public const string MENU_ITEM_PARAMETER = "KEP/MaterialSwap";
 
@@ -28,7 +27,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
         /// </summary>
         public static GenerationResult CreateMaterialSwap(GameObject targetRoot, CopiedMaterialData copiedData)
         {
-            if (!ValidateParameters(targetRoot, copiedData, out var validationResult))
+            if (!MAMaterialHelperUtils.ValidateGenerationParameters(targetRoot, copiedData, out var validationResult))
                 return validationResult;
 
             try
@@ -57,7 +56,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
         /// </summary>
         public static GenerationResult CreateMaterialSwapPerObject(GameObject targetRoot, CopiedMaterialData copiedData)
         {
-            if (!ValidateParameters(targetRoot, copiedData, out var validationResult))
+            if (!MAMaterialHelperUtils.ValidateGenerationParameters(targetRoot, copiedData, out var validationResult))
                 return validationResult;
 
             try
@@ -189,7 +188,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
             Undo.SetCurrentGroupName(undoGroupName);
             int undoGroup = Undo.GetCurrentGroup();
 
-            var (colorMenu, isNewMenu) = EnsureColorMenu(targetRoot);
+            var (colorMenu, isNewMenu) = MAMaterialHelperUtils.EnsureColorMenu(targetRoot);
             var groups = MAMaterialHelperSession.GetCopiedDataGroups();
 
             if (groups.Count == 0)
@@ -308,51 +307,6 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                                "代わりに「Create Material Setter」を使用してください。\n" +
                                "Please use 'Create Material Setter' instead.";
             return errorMessage;
-        }
-
-        /// <summary>
-        /// Validates input parameters for material swap generation
-        /// </summary>
-        private static bool ValidateParameters(GameObject targetRoot, CopiedMaterialData copiedData, out GenerationResult result)
-        {
-#if !MODULAR_AVATAR_INSTALLED
-            result = new GenerationResult
-            {
-                success = false,
-                message = "Modular Avatar is not installed"
-            };
-            return false;
-#endif
-
-            if (targetRoot == null || copiedData == null)
-            {
-                result = new GenerationResult
-                {
-                    success = false,
-                    message = "Invalid parameters"
-                };
-                return false;
-            }
-
-            result = default;
-            return true;
-        }
-
-        /// <summary>
-        /// Ensures Color Menu exists and returns it with creation status
-        /// </summary>
-        private static (Transform colorMenu, bool isNewMenu) EnsureColorMenu(GameObject targetRoot)
-        {
-            Transform colorMenu = targetRoot.transform.Find(COLOR_MENU_NAME);
-            bool isNewMenu = colorMenu == null;
-
-            if (isNewMenu)
-            {
-                var colorMenuObj = ModularAvatarIntegration.CreateColorMenu(targetRoot, COLOR_MENU_NAME);
-                colorMenu = colorMenuObj.transform;
-            }
-
-            return (colorMenu, isNewMenu);
         }
 
         /// <summary>

--- a/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
@@ -19,6 +19,10 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
         private const string COLOR_PREFIX = "Color";
         public const string MENU_ITEM_PARAMETER = "KEP/MaterialSwap";
 
+        private delegate GameObject CreateVariationCallback(Transform colorMenu, string colorName, int colorNumber, GameObject targetRoot, string parameterName);
+        private delegate int ProcessGroupCallback(GameObject colorVariation, GameObject targetRoot, List<MaterialSetupData> group, out string limitationError);
+        private delegate string SuccessMessageFactory(bool isNewMenu, int groupCount, int startingColorNumber);
+
         /// <summary>
         /// Creates material swap setup on the target GameObject
         /// </summary>
@@ -29,104 +33,14 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
 
             try
             {
-                // Set up Undo group for this operation
-                Undo.SetCurrentGroupName("Create Material Swap");
-                int undoGroup = Undo.GetCurrentGroup();
-
-                var (colorMenu, isNewMenu) = EnsureColorMenu(targetRoot);
-                var groups = MAMaterialHelperSession.GetCopiedDataGroups();
-
-                if (groups.Count == 0)
-                {
-                    return new GenerationResult
-                    {
-                        success = false,
-                        message = "No material setup groups found"
-                    };
-                }
-
-                var createdVariations = new List<GameObject>();
-                int totalSuccessfulMatches = 0;
-                int startingColorNumber = MAMaterialHelperUtils.DetermineNextColorNumber(colorMenu, COLOR_PREFIX);
-                string uniqueParameterName = ModularAvatarIntegration.DetermineParameterNameForColorMenu(colorMenu, targetRoot, MENU_ITEM_PARAMETER);
-                var limitationErrors = new List<string>();
-
-                // Create color variations for each group
-                for (int groupIndex = 0; groupIndex < groups.Count; groupIndex++)
-                {
-                    var group = groups[groupIndex];
-                    int colorNumber = startingColorNumber + groupIndex;
-                    string colorName = $"{COLOR_PREFIX}{colorNumber}";
-
-                    var colorVariation = ModularAvatarIntegration.CreateMenuToggleVariation(colorMenu, colorName, colorNumber, targetRoot.name, uniqueParameterName);
-#if MODULAR_AVATAR_INSTALLED
-                    Undo.AddComponent<ModularAvatarMaterialSwap>(colorVariation);
-#endif
-                    createdVariations.Add(colorVariation);
-
-                    // Create material swaps for this group
-                    int groupMatches = SetupMaterialSwapsForGroup(colorVariation, targetRoot, group, out string limitationError);
-                    if (!string.IsNullOrEmpty(limitationError))
-                    {
-                        limitationErrors.Add(limitationError);
-                    }
-
-                    totalSuccessfulMatches += groupMatches;
-
-                    if (groupMatches == 0)
-                    {
-                        Debug.LogWarning($"[MA Material Helper] No matching objects found for group {groupIndex + 1}");
-                    }
-                }
-
-                if (totalSuccessfulMatches == 0)
-                {
-                    // Clean up all created variations
-                    foreach (var variation in createdVariations)
-                    {
-                        Undo.DestroyObjectImmediate(variation);
-                    }
-
-                    if (isNewMenu)
-                    {
-                        Undo.DestroyObjectImmediate(colorMenu.gameObject);
-                    }
-
-                    Undo.CollapseUndoOperations(undoGroup);
-
-                    return new GenerationResult
-                    {
-                        success = false,
-                        message = "No matching objects found between source and target"
-                    };
-                }
-
-                EditorUtility.SetDirty(targetRoot);
-
-                // Collapse all Undo operations into a single operation
-                Undo.CollapseUndoOperations(undoGroup);
-
-                string resultMessage = isNewMenu
-                    ? $"Created Color Menu with {groups.Count} color variations (Color{startingColorNumber}-Color{startingColorNumber + groups.Count - 1})"
-                    : $"Added {groups.Count} color variations (Color{startingColorNumber}-Color{startingColorNumber + groups.Count - 1})";
-
-                // If there were limitation errors, return them as warning
-                if (limitationErrors.Count > 0)
-                {
-                    return new GenerationResult
-                    {
-                        success = false,
-                        message = string.Join("\n\n", limitationErrors),
-                        createdObject = createdVariations.Count > 0 ? createdVariations[0] : null
-                    };
-                }
-
-                return new GenerationResult
-                {
-                    success = true,
-                    message = resultMessage,
-                    createdObject = createdVariations.Count > 0 ? createdVariations[0] : null
-                };
+                return CreateMaterialSwapCore(
+                    targetRoot,
+                    "Create Material Swap",
+                    CreateMaterialSwapVariation,
+                    SetupMaterialSwapsForGroup,
+                    (isNewMenu, groupCount, startingColorNumber) => isNewMenu
+                        ? $"Created Color Menu with {groupCount} color variations (Color{startingColorNumber}-Color{startingColorNumber + groupCount - 1})"
+                        : $"Added {groupCount} color variations (Color{startingColorNumber}-Color{startingColorNumber + groupCount - 1})");
             }
             catch (Exception e)
             {
@@ -148,101 +62,14 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
 
             try
             {
-                // Set up Undo group for this operation
-                Undo.SetCurrentGroupName("Create Material Swap Per Object");
-                int undoGroup = Undo.GetCurrentGroup();
-
-                var (colorMenu, isNewMenu) = EnsureColorMenu(targetRoot);
-                var groups = MAMaterialHelperSession.GetCopiedDataGroups();
-
-                if (groups.Count == 0)
-                {
-                    return new GenerationResult
-                    {
-                        success = false,
-                        message = "No material setup groups found"
-                    };
-                }
-
-                var createdVariations = new List<GameObject>();
-                int totalSuccessfulMatches = 0;
-                int startingColorNumber = MAMaterialHelperUtils.DetermineNextColorNumber(colorMenu, COLOR_PREFIX);
-                string uniqueParameterName = ModularAvatarIntegration.DetermineParameterNameForColorMenu(colorMenu, targetRoot, MENU_ITEM_PARAMETER);
-                var limitationErrors = new List<string>();
-
-                // Create color variations for each group
-                for (int groupIndex = 0; groupIndex < groups.Count; groupIndex++)
-                {
-                    var group = groups[groupIndex];
-                    int colorNumber = startingColorNumber + groupIndex;
-                    string colorName = $"{COLOR_PREFIX}{colorNumber}";
-
-                    var colorVariation = ModularAvatarIntegration.CreateMenuToggleVariation(colorMenu, colorName, colorNumber, targetRoot.name, uniqueParameterName);
-                    createdVariations.Add(colorVariation);
-
-                    // Create material swaps for this group (per-object mode)
-                    int groupMatches = SetupMaterialSwapsPerObjectForGroup(colorVariation, targetRoot, group, out string limitationError);
-                    if (!string.IsNullOrEmpty(limitationError))
-                    {
-                        limitationErrors.Add(limitationError);
-                    }
-
-                    totalSuccessfulMatches += groupMatches;
-
-                    if (groupMatches == 0)
-                    {
-                        Debug.LogWarning($"[MA Material Helper] No matching objects found for group {groupIndex + 1}");
-                    }
-                }
-
-                if (totalSuccessfulMatches == 0)
-                {
-                    // Clean up all created variations
-                    foreach (var variation in createdVariations)
-                    {
-                        Undo.DestroyObjectImmediate(variation);
-                    }
-
-                    if (isNewMenu)
-                    {
-                        Undo.DestroyObjectImmediate(colorMenu.gameObject);
-                    }
-
-                    Undo.CollapseUndoOperations(undoGroup);
-
-                    return new GenerationResult
-                    {
-                        success = false,
-                        message = "No matching objects found between source and target"
-                    };
-                }
-
-                EditorUtility.SetDirty(targetRoot);
-
-                // Collapse all Undo operations into a single operation
-                Undo.CollapseUndoOperations(undoGroup);
-
-                string resultMessage = isNewMenu
-                    ? $"Created Color Menu with {groups.Count} color variations (per-object components)"
-                    : $"Added {groups.Count} color variations with per-object components";
-
-                // If there were limitation errors, return them as warning
-                if (limitationErrors.Count > 0)
-                {
-                    return new GenerationResult
-                    {
-                        success = false,
-                        message = string.Join("\n\n", limitationErrors),
-                        createdObject = createdVariations.Count > 0 ? createdVariations[0] : null
-                    };
-                }
-
-                return new GenerationResult
-                {
-                    success = true,
-                    message = resultMessage,
-                    createdObject = createdVariations.Count > 0 ? createdVariations[0] : null
-                };
+                return CreateMaterialSwapCore(
+                    targetRoot,
+                    "Create Material Swap Per Object",
+                    CreateMenuToggleVariation,
+                    SetupMaterialSwapsPerObjectForGroup,
+                    (isNewMenu, groupCount, _) => isNewMenu
+                        ? $"Created Color Menu with {groupCount} color variations (per-object components)"
+                        : $"Added {groupCount} color variations with per-object components");
             }
             catch (Exception e)
             {
@@ -350,6 +177,121 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
         #endregion
 
         #region Private Methods
+
+        private static GenerationResult CreateMaterialSwapCore(
+            GameObject targetRoot,
+            string undoGroupName,
+            CreateVariationCallback createVariation,
+            ProcessGroupCallback processGroup,
+            SuccessMessageFactory createSuccessMessage)
+        {
+            // Set up Undo group for this operation
+            Undo.SetCurrentGroupName(undoGroupName);
+            int undoGroup = Undo.GetCurrentGroup();
+
+            var (colorMenu, isNewMenu) = EnsureColorMenu(targetRoot);
+            var groups = MAMaterialHelperSession.GetCopiedDataGroups();
+
+            if (groups.Count == 0)
+            {
+                return new GenerationResult
+                {
+                    success = false,
+                    message = "No material setup groups found"
+                };
+            }
+
+            var createdVariations = new List<GameObject>();
+            int totalSuccessfulMatches = 0;
+            int startingColorNumber = MAMaterialHelperUtils.DetermineNextColorNumber(colorMenu, COLOR_PREFIX);
+            string uniqueParameterName = ModularAvatarIntegration.DetermineParameterNameForColorMenu(colorMenu, targetRoot, MENU_ITEM_PARAMETER);
+            var limitationErrors = new List<string>();
+
+            // Create color variations for each group
+            for (int groupIndex = 0; groupIndex < groups.Count; groupIndex++)
+            {
+                var group = groups[groupIndex];
+                int colorNumber = startingColorNumber + groupIndex;
+                string colorName = $"{COLOR_PREFIX}{colorNumber}";
+
+                var colorVariation = createVariation(colorMenu, colorName, colorNumber, targetRoot, uniqueParameterName);
+                createdVariations.Add(colorVariation);
+
+                int groupMatches = processGroup(colorVariation, targetRoot, group, out string limitationError);
+                if (!string.IsNullOrEmpty(limitationError))
+                {
+                    limitationErrors.Add(limitationError);
+                }
+
+                totalSuccessfulMatches += groupMatches;
+
+                if (groupMatches == 0)
+                {
+                    Debug.LogWarning($"[MA Material Helper] No matching objects found for group {groupIndex + 1}");
+                }
+            }
+
+            if (totalSuccessfulMatches == 0)
+            {
+                // Clean up all created variations
+                foreach (var variation in createdVariations)
+                {
+                    Undo.DestroyObjectImmediate(variation);
+                }
+
+                if (isNewMenu)
+                {
+                    Undo.DestroyObjectImmediate(colorMenu.gameObject);
+                }
+
+                Undo.CollapseUndoOperations(undoGroup);
+
+                return new GenerationResult
+                {
+                    success = false,
+                    message = "No matching objects found between source and target"
+                };
+            }
+
+            EditorUtility.SetDirty(targetRoot);
+
+            // Collapse all Undo operations into a single operation
+            Undo.CollapseUndoOperations(undoGroup);
+
+            string resultMessage = createSuccessMessage(isNewMenu, groups.Count, startingColorNumber);
+
+            // If there were limitation errors, return them as warning
+            if (limitationErrors.Count > 0)
+            {
+                return new GenerationResult
+                {
+                    success = false,
+                    message = string.Join("\n\n", limitationErrors),
+                    createdObject = createdVariations.Count > 0 ? createdVariations[0] : null
+                };
+            }
+
+            return new GenerationResult
+            {
+                success = true,
+                message = resultMessage,
+                createdObject = createdVariations.Count > 0 ? createdVariations[0] : null
+            };
+        }
+
+        private static GameObject CreateMaterialSwapVariation(Transform colorMenu, string colorName, int colorNumber, GameObject targetRoot, string parameterName)
+        {
+            var colorVariation = ModularAvatarIntegration.CreateMenuToggleVariation(colorMenu, colorName, colorNumber, targetRoot.name, parameterName);
+#if MODULAR_AVATAR_INSTALLED
+            Undo.AddComponent<ModularAvatarMaterialSwap>(colorVariation);
+#endif
+            return colorVariation;
+        }
+
+        private static GameObject CreateMenuToggleVariation(Transform colorMenu, string colorName, int colorNumber, GameObject targetRoot, string parameterName)
+        {
+            return ModularAvatarIntegration.CreateMenuToggleVariation(colorMenu, colorName, colorNumber, targetRoot.name, parameterName);
+        }
 
         /// <summary>
         /// Builds error message for Material Swap limitation

--- a/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
@@ -18,7 +18,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
         private const string COLOR_PREFIX = "Color";
         public const string MENU_ITEM_PARAMETER = "KEP/MaterialSwap";
 
-        private delegate GameObject CreateVariationCallback(Transform colorMenu, string colorName, int colorNumber, GameObject targetRoot, string parameterName);
+        private delegate GameObject CreateVariationCallback(Transform colorMenu, string colorName, int colorNumber, string gameObjectName, string parameterName);
         private delegate int ProcessGroupCallback(GameObject colorVariation, GameObject targetRoot, List<MaterialSetupData> group, out string limitationError);
         private delegate string SuccessMessageFactory(bool isNewMenu, int groupCount, int startingColorNumber);
 
@@ -213,7 +213,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                 int colorNumber = startingColorNumber + groupIndex;
                 string colorName = $"{COLOR_PREFIX}{colorNumber}";
 
-                var colorVariation = createVariation(colorMenu, colorName, colorNumber, targetRoot, uniqueParameterName);
+                var colorVariation = createVariation(colorMenu, colorName, colorNumber, targetRoot.name, uniqueParameterName);
                 createdVariations.Add(colorVariation);
 
                 int groupMatches = processGroup(colorVariation, targetRoot, group, out string limitationError);
@@ -278,18 +278,18 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
             };
         }
 
-        private static GameObject CreateMaterialSwapVariation(Transform colorMenu, string colorName, int colorNumber, GameObject targetRoot, string parameterName)
+        private static GameObject CreateMaterialSwapVariation(Transform colorMenu, string colorName, int colorNumber, string gameObjectName, string parameterName)
         {
-            var colorVariation = ModularAvatarIntegration.CreateMenuToggleVariation(colorMenu, colorName, colorNumber, targetRoot.name, parameterName);
+            var colorVariation = ModularAvatarIntegration.CreateMenuToggleVariation(colorMenu, colorName, colorNumber, gameObjectName, parameterName);
 #if MODULAR_AVATAR_INSTALLED
             Undo.AddComponent<ModularAvatarMaterialSwap>(colorVariation);
 #endif
             return colorVariation;
         }
 
-        private static GameObject CreateMenuToggleVariation(Transform colorMenu, string colorName, int colorNumber, GameObject targetRoot, string parameterName)
+        private static GameObject CreateMenuToggleVariation(Transform colorMenu, string colorName, int colorNumber, string gameObjectName, string parameterName)
         {
-            return ModularAvatarIntegration.CreateMenuToggleVariation(colorMenu, colorName, colorNumber, targetRoot.name, parameterName);
+            return ModularAvatarIntegration.CreateMenuToggleVariation(colorMenu, colorName, colorNumber, gameObjectName, parameterName);
         }
 
         /// <summary>


### PR DESCRIPTION
## 概要

MaterialSetterGenerator と MaterialSwapGenerator に重複していた MA generation のコアロジックを共有ユーティリティに集約しました。

- `ModularAvatarIntegration.CreateMenuToggleVariation()` を新設し、MenuItem toggle だけを持つ variation 生成を共通化
- `MAMaterialHelperUtils.ValidateGenerationParameters()` / `EnsureColorMenu()` を抽出し、両 Generator の重複バリデーション・Color Menu 生成ロジックを一本化
- `MaterialSwapGenerator` 内に `CreateMaterialSwapCore()` を導入し、`CreateMaterialSwap` / `CreateMaterialSwapPerObject` で重複していたループ・Undo・クリーンアップ処理をデリゲートで統一

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `Common/MAMaterialHelperUtils.cs` | `ValidateGenerationParameters`, `EnsureColorMenu`, `ColorMenuName` を追加 |
| `Common/ModularAvatarIntegration.cs` | `CreateMenuToggleVariation` を追加、`CreateColorVariation`（呼び出し元ゼロ）を削除 |
| `MaterialSetter/MaterialSetterGenerator.cs` | 重複していた private ヘルパーを共有実装に置き換え |
| `MaterialSwap/MaterialSwapGenerator.cs` | `CreateMaterialSwapCore` によるデリゲートパターンで2メソッドを統合 |
