### PR TITLE
refactor: share path/score logic with ObjectMatcher

### DIFF
--- a/Editor/MAMaterialHelper/Common/ObjectMatcher.cs
+++ b/Editor/MAMaterialHelper/Common/ObjectMatcher.cs
@@ -23,8 +23,8 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
         private const float FuzzyAncestorBonus = 20f;
         private const int EligibilityMinTokenLength = 3;
         private const int RankingMinTokenLength = 1;
-        private const float NormalizedNameScore = 100f;
-        private const float FuzzyNameScore = 60f;
+        internal const float NormalizedNameScore = 100f;
+        internal const float FuzzyNameScore = 60f;
 
         private static readonly char[] NameSeparators = { '_', '-', '.', ' ' };
 

--- a/Editor/MaterialCopier.cs
+++ b/Editor/MaterialCopier.cs
@@ -257,6 +257,13 @@ namespace Kanameliser.EditorPlus
         {
             if (copiedMaterials == null || copiedMaterials.Count == 0) return null;
 
+            // Keep in sync with ObjectMatcher's tier order, P5 eligibility, shared
+            // scoring helpers, and name-score constants. Intentional differences:
+            // this searches from paste target to copied source data, allows empty
+            // rendererType metadata, uses RootNameBonus for multi-root copy/paste
+            // disambiguation, and does not share Transform collection, logging, or
+            // matchedTargets duplicate tracking.
+
             // Apply renderer type filter to base candidates
             var baseCandidates = copiedMaterials.Where(d =>
                 string.IsNullOrEmpty(targetRendererType) ||
@@ -341,7 +348,7 @@ namespace Kanameliser.EditorPlus
 
         /// <summary>
         /// Selects the best source MaterialData for P5 fuzzy tier using combined name + path scoring.
-        /// Score: NameScore(norm=100, fuzzy=60) + PathSegmentScore + AncestorContextScore + RootNameBonus.
+        /// Score: NameScore + PathSegmentScore + AncestorContextScore + RootNameBonus.
         /// Tiebreakers: highest score, then depth proximity, then Levenshtein distance.
         /// </summary>
         private static MaterialData SelectBestFuzzySource(List<MaterialData> candidates, string targetName, string targetRelativePath, int targetDepth, string targetRootName = "")
@@ -355,8 +362,8 @@ namespace Kanameliser.EditorPlus
                 {
                     string normalizedSource = ObjectMatcher.NormalizeName(d.objectName);
                     float nameScore = string.Equals(normalizedTarget, normalizedSource, StringComparison.OrdinalIgnoreCase)
-                        ? 100f
-                        : 60f;
+                        ? ObjectMatcher.NormalizedNameScore
+                        : ObjectMatcher.FuzzyNameScore;
                     return nameScore +
                            ObjectMatcher.PathSegmentScore(targetRelativePath, d.relativePath) +
                            ObjectMatcher.AncestorContextScore(d.rootObjectName, targetRelativePath) +

--- a/Editor/MaterialCopier.cs
+++ b/Editor/MaterialCopier.cs
@@ -451,19 +451,8 @@ namespace Kanameliser.EditorPlus
         /// </summary>
         private static string GetRelativePath(GameObject obj, GameObject rootObject)
         {
-            if (obj == null) return "";
-            if (obj == rootObject) return "";
-
-            string path = obj.name;
-            Transform parent = obj.transform.parent;
-
-            while (parent != null && parent.gameObject != rootObject)
-            {
-                path = parent.name + "/" + path;
-                parent = parent.parent;
-            }
-
-            return path;
+            if (obj == null || rootObject == null) return "";
+            return ObjectMatcher.GetRelativePathFromRoot(obj.transform, rootObject.transform);
         }
     }
 }

--- a/Editor/Tests/MatchingRegressionTests.cs
+++ b/Editor/Tests/MatchingRegressionTests.cs
@@ -426,6 +426,50 @@ namespace Kanameliser.EditorPlus.Tests
             }
         }
 
+        [Test]
+        public void PasteMaterials_UsesNestedRelativePathForDuplicateNames()
+        {
+            var targetRoot = CreateGameObject("NestedTarget");
+            var materialA = CreateMaterial("MaterialA");
+            var materialB = CreateMaterial("MaterialB");
+            var beforeA = CreateMaterial("BeforeA");
+            var beforeB = CreateMaterial("BeforeB");
+
+            var bodyA = CreateGameObject("Body", CreateGameObject("VariantA", targetRoot)).AddComponent<MeshRenderer>();
+            bodyA.sharedMaterial = beforeA;
+            var bodyB = CreateGameObject("Body", CreateGameObject("VariantB", targetRoot)).AddComponent<MeshRenderer>();
+            bodyB.sharedMaterial = beforeB;
+
+            var copiedData = new[]
+            {
+                Data("Body", "VariantA/Body", 2, targetRoot.name, "MeshRenderer", materialA),
+                Data("Body", "VariantB/Body", 2, targetRoot.name, "MeshRenderer", materialB)
+            };
+
+            var undoPerformed = false;
+            try
+            {
+                Undo.IncrementCurrentGroup();
+                var logs = CaptureLogs("[MaterialCopier]", () => MaterialCopier.PasteMaterialsForTests(new[] { targetRoot }, copiedData));
+
+                Assert.That(logs, Is.EqualTo(new[] { "Log: [MaterialCopier] Applied materials to 2 objects." }));
+                Assert.That(bodyA.sharedMaterial, Is.SameAs(materialA));
+                Assert.That(bodyB.sharedMaterial, Is.SameAs(materialB));
+
+                Undo.PerformUndo();
+                undoPerformed = true;
+                Assert.That(bodyA.sharedMaterial, Is.SameAs(beforeA));
+                Assert.That(bodyB.sharedMaterial, Is.SameAs(beforeB));
+            }
+            finally
+            {
+                if (!undoPerformed)
+                {
+                    Undo.PerformUndo();
+                }
+            }
+        }
+
         private static MaterialData Data(string name, string path, int depth, string rootName = "Source", string rendererType = "MeshRenderer", params Material[] materials)
         {
             return new MaterialData(name, materials ?? Array.Empty<Material>(), depth, path, rootName, rendererType);


### PR DESCRIPTION
## 概要

`MaterialCopier` と `ObjectMatcher` の間でコードが重複していた2つの箇所を統合するリファクタリング

- `GetRelativePath` の独自実装を `ObjectMatcher.GetRelativePathFromRoot` への委譲に置き換え
- P5 スコアリングで使用していたハードコードされた `100f` / `60f` を `ObjectMatcher.NormalizedNameScore` / `FuzzyNameScore` の共有定数に置き換え

あわせて、`FindMatchingMaterialData` の意図的な設計上の差異（探索方向・rendererType 省略許可・RootNameBonus 等）をコメントで明文化

## 変更内容

- **ObjectMatcher.cs**: `NormalizedNameScore` / `FuzzyNameScore` を `private` → `internal` に変更して外部参照を可能に
- **MaterialCopier.cs**:
  - `GetRelativePath` を `ObjectMatcher.GetRelativePathFromRoot` に委譲（同一の動作を維持）
  - P5 スコア定数をハードコードから共有定数に変更
  - ObjectMatcher との意図的な差異を説明するコメントを追加
- **MatchingRegressionTests.cs**: 同名オブジェクトが異なるパスに存在する場合に正しくマテリアルを区別して適用できることを確認するリグレッションテストを追加