### PR TITLE
refactor: name UI layout constants and unify drag-and-drop handling

### DIFF
--- a/Editor/AOBoundsSetter/TransformSelectorWindow.cs
+++ b/Editor/AOBoundsSetter/TransformSelectorWindow.cs
@@ -12,6 +12,15 @@ namespace Kanameliser.EditorPlus
     /// </summary>
     public class TransformSelectorWindow : EditorWindow
     {
+        private const float WindowWidth = 300f;
+        private const float WindowHeight = 400f;
+        private const float WindowPadding = 5f;
+        private const float SearchFieldMarginBottom = 5f;
+        private const float TransformListBorderWidth = 1f;
+        private static readonly Color PlaceholderTextColor = new Color(0.5f, 0.5f, 0.5f, 0.5f);
+        private static readonly Color TransformListBorderColor = new Color(0.2f, 0.2f, 0.2f);
+        private static readonly Color TransformItemHoverColor = new Color(0.3f, 0.5f, 0.8f, 0.5f);
+
         private GameObject rootObject;
         private Action<Transform> onSelectionChanged;
         private TextField searchField;
@@ -27,7 +36,7 @@ namespace Kanameliser.EditorPlus
             window.onSelectionChanged = onSelectionChanged;
 
             // Position the window below the field
-            Vector2 windowSize = new Vector2(300, 400);
+            Vector2 windowSize = new Vector2(WindowWidth, WindowHeight);
 
             // Convert to screen position, align to the right edge of the field
             Vector2 screenPosition = GUIUtility.GUIToScreenPoint(new Vector2(fieldRect.xMax - windowSize.x, fieldRect.yMax));
@@ -57,14 +66,14 @@ namespace Kanameliser.EditorPlus
         public void CreateGUI()
         {
             var root = rootVisualElement;
-            root.style.paddingTop = 5;
-            root.style.paddingBottom = 5;
-            root.style.paddingLeft = 5;
-            root.style.paddingRight = 5;
+            root.style.paddingTop = WindowPadding;
+            root.style.paddingBottom = WindowPadding;
+            root.style.paddingLeft = WindowPadding;
+            root.style.paddingRight = WindowPadding;
 
             // Search field
             searchField = new TextField();
-            searchField.style.marginBottom = 5;
+            searchField.style.marginBottom = SearchFieldMarginBottom;
             searchField.RegisterValueChangedCallback(OnSearchTextChanged);
 
             // Add placeholder text
@@ -72,7 +81,7 @@ namespace Kanameliser.EditorPlus
             placeholderLabel.style.position = Position.Absolute;
             placeholderLabel.style.left = 3;
             placeholderLabel.style.top = 2;
-            placeholderLabel.style.color = new Color(0.5f, 0.5f, 0.5f, 0.5f);
+            placeholderLabel.style.color = PlaceholderTextColor;
             placeholderLabel.pickingMode = PickingMode.Ignore;
 
             searchField.RegisterCallback<FocusInEvent>(evt =>
@@ -99,14 +108,14 @@ namespace Kanameliser.EditorPlus
             // Transform list
             transformListScrollView = new ScrollView();
             transformListScrollView.style.flexGrow = 1;
-            transformListScrollView.style.borderTopWidth = 1;
-            transformListScrollView.style.borderBottomWidth = 1;
-            transformListScrollView.style.borderLeftWidth = 1;
-            transformListScrollView.style.borderRightWidth = 1;
-            transformListScrollView.style.borderTopColor = new Color(0.2f, 0.2f, 0.2f);
-            transformListScrollView.style.borderBottomColor = new Color(0.2f, 0.2f, 0.2f);
-            transformListScrollView.style.borderLeftColor = new Color(0.2f, 0.2f, 0.2f);
-            transformListScrollView.style.borderRightColor = new Color(0.2f, 0.2f, 0.2f);
+            transformListScrollView.style.borderTopWidth = TransformListBorderWidth;
+            transformListScrollView.style.borderBottomWidth = TransformListBorderWidth;
+            transformListScrollView.style.borderLeftWidth = TransformListBorderWidth;
+            transformListScrollView.style.borderRightWidth = TransformListBorderWidth;
+            transformListScrollView.style.borderTopColor = TransformListBorderColor;
+            transformListScrollView.style.borderBottomColor = TransformListBorderColor;
+            transformListScrollView.style.borderLeftColor = TransformListBorderColor;
+            transformListScrollView.style.borderRightColor = TransformListBorderColor;
             root.Add(transformListScrollView);
 
             RefreshTransformList();
@@ -193,7 +202,7 @@ namespace Kanameliser.EditorPlus
             // Hover effect
             item.RegisterCallback<MouseEnterEvent>(evt =>
             {
-                item.style.backgroundColor = new Color(0.3f, 0.5f, 0.8f, 0.5f);
+                item.style.backgroundColor = TransformItemHoverColor;
             });
             item.RegisterCallback<MouseLeaveEvent>(evt =>
             {

--- a/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterConfirmationWindow.cs
+++ b/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterConfirmationWindow.cs
@@ -7,8 +7,6 @@ namespace Kanameliser.EditorPlus
 {
     internal class MissingBlendShapeInserterConfirmationWindow : EditorWindow
     {
-        private const float WindowMinWidth = 600f;
-        private const float WindowMinHeight = 400f;
         private const string BlendShapePrefix = "blendShape.";
 
         private static List<AnimationClip> animationClips = new List<AnimationClip>();
@@ -52,7 +50,7 @@ namespace Kanameliser.EditorPlus
         public static void ShowWindow()
         {
             var window = GetWindow<MissingBlendShapeInserterConfirmationWindow>("変更内容の確認");
-            window.minSize = new Vector2(WindowMinWidth, WindowMinHeight);
+            window.minSize = MissingBlendShapeInserterLayoutConstants.WindowMinSize;
             window.CalculateMissingBlendShapes(); // 変更点の計算を開始
         }
 
@@ -154,13 +152,6 @@ namespace Kanameliser.EditorPlus
                 if (clip == null)
                     continue;
 
-                // アニメーションクリップであることを確認
-                if (!(clip is AnimationClip))
-                {
-                    ShowInvalidClipError(clip);
-                    continue;
-                }
-
                 // 欠落しているBlendShapeを取得
                 List<string> missingBlendShapes = GetMissingBlendShapes(clip, allBlendShapeNames);
 
@@ -180,12 +171,6 @@ namespace Kanameliser.EditorPlus
             }
 
             changesCalculated = true; // 変更点の計算が完了
-        }
-
-        // 無効なクリップのエラー表示
-        private void ShowInvalidClipError(AnimationClip clip)
-        {
-            EditorUtility.DisplayDialog("エラー", $"指定されたオブジェクトはAnimationClipではありません。オブジェクト名: {clip.name}", "OK");
         }
 
         // BlendShapeの値を取得

--- a/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterConfirmationWindow.cs
+++ b/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterConfirmationWindow.cs
@@ -7,6 +7,10 @@ namespace Kanameliser.EditorPlus
 {
     internal class MissingBlendShapeInserterConfirmationWindow : EditorWindow
     {
+        private const float WindowMinWidth = 600f;
+        private const float WindowMinHeight = 400f;
+        private const string BlendShapePrefix = "blendShape.";
+
         private static List<AnimationClip> animationClips = new List<AnimationClip>();
         private static string skinnedMeshRendererPath = "Body";
         private static bool overwriteExistingFiles = true;
@@ -48,7 +52,7 @@ namespace Kanameliser.EditorPlus
         public static void ShowWindow()
         {
             var window = GetWindow<MissingBlendShapeInserterConfirmationWindow>("変更内容の確認");
-            window.minSize = new Vector2(600, 400);
+            window.minSize = new Vector2(WindowMinWidth, WindowMinHeight);
             window.CalculateMissingBlendShapes(); // 変更点の計算を開始
         }
 
@@ -207,7 +211,7 @@ namespace Kanameliser.EditorPlus
             // 各BlendShapeの値を取得
             foreach (var blendShapeName in blendShapeNames)
             {
-                string name = blendShapeName.Substring("blendShape.".Length);
+                string name = blendShapeName.Substring(BlendShapePrefix.Length);
                 int index = smr.sharedMesh.GetBlendShapeIndex(name);
                 float value = index != -1 ? smr.GetBlendShapeWeight(index) : 0f;
                 blendShapeValues[blendShapeName] = value;
@@ -298,7 +302,7 @@ namespace Kanameliser.EditorPlus
         {
             return binding.type == typeof(SkinnedMeshRenderer) &&
                    binding.path.Equals(skinnedMeshRendererPath) &&
-                   binding.propertyName.StartsWith("blendShape.") &&
+                   binding.propertyName.StartsWith(BlendShapePrefix) &&
                    !binding.isPPtrCurve;
         }
 

--- a/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterWindow.cs
+++ b/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterWindow.cs
@@ -4,14 +4,17 @@ using System.Collections.Generic;
 
 namespace Kanameliser.EditorPlus
 {
+    internal static class MissingBlendShapeInserterLayoutConstants
+    {
+        internal static readonly Vector2 WindowMinSize = new Vector2(600f, 400f);
+    }
+
     internal class MissingBlendShapeInserterWindow : EditorWindow
     {
-        private const float WindowMinWidth = 600f;
-        private const float WindowMinHeight = 400f;
         private const float DropAreaHeight = 50.0f;
         private const float ClipListItemSpacing = 4f;
         private const float ClipListMaxHeight = 200f;
-        private const float ClipListHeightPadding = 10f;
+        private const float ClipListScrollViewExtraHeight = 10f;
 
         // ユーザーが指定するアニメーションクリップのリスト
         public List<AnimationClip> animationClips = new List<AnimationClip>();
@@ -35,7 +38,7 @@ namespace Kanameliser.EditorPlus
         public static void ShowWindow()
         {
             var window = GetWindow<MissingBlendShapeInserterWindow>("Missing BlendShape Inserter");
-            window.minSize = new Vector2(WindowMinWidth, WindowMinHeight);
+            window.minSize = MissingBlendShapeInserterLayoutConstants.WindowMinSize;
         }
 
         private void OnGUI()
@@ -98,7 +101,7 @@ namespace Kanameliser.EditorPlus
                     if (evt.type == EventType.DragPerform)
                     {
                         DragAndDrop.AcceptDrag();
-                        dropped = DragAndDrop.objectReferences;
+                        dropped = (Object[])DragAndDrop.objectReferences.Clone();
                         evt.Use(); // イベントを使用済みにする
                         return true;
                     }
@@ -141,7 +144,7 @@ namespace Kanameliser.EditorPlus
             float listHeight = Mathf.Min(itemCount * itemHeight, ClipListMaxHeight);
 
             // スクロールビューの開始
-            scrollPos = EditorGUILayout.BeginScrollView(scrollPos, GUILayout.Height(listHeight + ClipListHeightPadding));
+            scrollPos = EditorGUILayout.BeginScrollView(scrollPos, GUILayout.Height(listHeight + ClipListScrollViewExtraHeight));
 
             // 各アニメーションクリップを描画
             int clipIndexToRemove = -1;

--- a/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterWindow.cs
+++ b/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterWindow.cs
@@ -6,6 +6,13 @@ namespace Kanameliser.EditorPlus
 {
     internal class MissingBlendShapeInserterWindow : EditorWindow
     {
+        private const float WindowMinWidth = 600f;
+        private const float WindowMinHeight = 400f;
+        private const float DropAreaHeight = 50.0f;
+        private const float ClipListItemSpacing = 4f;
+        private const float ClipListMaxHeight = 200f;
+        private const float ClipListHeightPadding = 10f;
+
         // ユーザーが指定するアニメーションクリップのリスト
         public List<AnimationClip> animationClips = new List<AnimationClip>();
 
@@ -28,7 +35,7 @@ namespace Kanameliser.EditorPlus
         public static void ShowWindow()
         {
             var window = GetWindow<MissingBlendShapeInserterWindow>("Missing BlendShape Inserter");
-            window.minSize = new Vector2(600, 400);
+            window.minSize = new Vector2(WindowMinWidth, WindowMinHeight);
         }
 
         private void OnGUI()
@@ -62,7 +69,7 @@ namespace Kanameliser.EditorPlus
             EditorGUILayout.LabelField("アニメーションファイルをドラッグ＆ドロップで指定", EditorStyles.boldLabel);
 
             // ドラッグ＆ドロップエリアを作成
-            Rect dropArea = GUILayoutUtility.GetRect(0.0f, 50.0f, GUILayout.ExpandWidth(true));
+            Rect dropArea = GUILayoutUtility.GetRect(0.0f, DropAreaHeight, GUILayout.ExpandWidth(true));
             GUI.Box(dropArea, "ここにアニメーションファイルをドラッグ＆ドロップ");
 
             // ドラッグ＆ドロップの処理を行う
@@ -130,12 +137,11 @@ namespace Kanameliser.EditorPlus
 
             // リストの高さを計算
             int itemCount = animationClips.Count;
-            float itemHeight = EditorGUIUtility.singleLineHeight + 4f;
-            float maxListHeight = 200f;
-            float listHeight = Mathf.Min(itemCount * itemHeight, maxListHeight);
+            float itemHeight = EditorGUIUtility.singleLineHeight + ClipListItemSpacing;
+            float listHeight = Mathf.Min(itemCount * itemHeight, ClipListMaxHeight);
 
             // スクロールビューの開始
-            scrollPos = EditorGUILayout.BeginScrollView(scrollPos, GUILayout.Height(listHeight + 10f));
+            scrollPos = EditorGUILayout.BeginScrollView(scrollPos, GUILayout.Height(listHeight + ClipListHeightPadding));
 
             // 各アニメーションクリップを描画
             int clipIndexToRemove = -1;

--- a/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterWindow.cs
+++ b/Editor/MissingBlendShapeInserter/MissingBlendShapeInserterWindow.cs
@@ -66,17 +66,19 @@ namespace Kanameliser.EditorPlus
             GUI.Box(dropArea, "ここにアニメーションファイルをドラッグ＆ドロップ");
 
             // ドラッグ＆ドロップの処理を行う
-            HandleDragAndDrop(dropArea);
+            if (TryHandleDropArea(dropArea, out Object[] dropped))
+                AddAnimationClips(dropped);
         }
 
         // ドラッグ＆ドロップの処理
-        private void HandleDragAndDrop(Rect dropArea)
+        private static bool TryHandleDropArea(Rect dropArea, out Object[] dropped)
         {
+            dropped = null;
             Event evt = Event.current;
 
             // マウスがドロップエリア内にあるか確認
             if (!dropArea.Contains(evt.mousePosition))
-                return;
+                return false;
 
             // イベントタイプによって処理を分岐
             switch (evt.type)
@@ -89,11 +91,14 @@ namespace Kanameliser.EditorPlus
                     if (evt.type == EventType.DragPerform)
                     {
                         DragAndDrop.AcceptDrag();
-                        AddAnimationClips(DragAndDrop.objectReferences);
+                        dropped = DragAndDrop.objectReferences;
                         evt.Use(); // イベントを使用済みにする
+                        return true;
                     }
                     break;
             }
+
+            return false;
         }
 
         // アニメーションクリップの追加
@@ -175,7 +180,8 @@ namespace Kanameliser.EditorPlus
 
             // 直前に描画した領域を取得し、ドラッグ＆ドロップ処理を設定
             Rect lastRect = GUILayoutUtility.GetLastRect();
-            HandleDragAndDropOnItem(lastRect, index);
+            if (TryHandleDropArea(lastRect, out Object[] dropped))
+                ReplaceAnimationClipAt(index, dropped);
 
             return false;
         }
@@ -192,33 +198,6 @@ namespace Kanameliser.EditorPlus
             {
                 // 重複していない場合はリストを更新
                 animationClips[index] = newClip;
-            }
-        }
-
-        // 個々のアイテムへのドラッグ＆ドロップ処理
-        private void HandleDragAndDropOnItem(Rect dropArea, int index)
-        {
-            Event evt = Event.current;
-
-            // マウスがアイテム領域内にあるか確認
-            if (!dropArea.Contains(evt.mousePosition))
-                return;
-
-            // イベントタイプによって処理を分岐
-            switch (evt.type)
-            {
-                case EventType.DragUpdated:
-                case EventType.DragPerform:
-                    // ドラッグ＆ドロップの見た目を変更
-                    DragAndDrop.visualMode = DragAndDropVisualMode.Copy;
-
-                    if (evt.type == EventType.DragPerform)
-                    {
-                        DragAndDrop.AcceptDrag();
-                        ReplaceAnimationClipAt(index, DragAndDrop.objectReferences);
-                        evt.Use(); // イベントを使用済みにする
-                    }
-                    break;
             }
         }
 


### PR DESCRIPTION
## 概要

- マジックナンバー・マジックカラーを名前付き定数に抽出
- 重複していたドラッグ＆ドロップ処理を1つのメソッドに統合
- レビュー指摘事項の修正

## 変更内容

### 定数の抽出（`TransformSelectorWindow`, `MissingBlendShapeInserterWindow`, `MissingBlendShapeInserterConfirmationWindow`）
- ウィンドウサイズ・パディング・ボーダー幅・色などのリテラル値を `private const` / `private static readonly` な定数に置き換え
- `"blendShape."` 文字列リテラルを `BlendShapePrefix` 定数に統一

### ドラッグ＆ドロップ処理の統合（`MissingBlendShapeInserterWindow`）
- ほぼ同一だった `HandleDragAndDrop` と `HandleDragAndDropOnItem` を削除
- `private static bool TryHandleDropArea(Rect, out Object[])` に統合し、メインドロップエリアとリスト各アイテムの両方で共用

### レビュー指摘への対応
- `MissingBlendShapeInserterConfirmationWindow` の到達不可能なガード `if (!(clip is AnimationClip))` を削除
- `DragAndDrop.objectReferences` のスナップショットコピー（`.ToArray()`）を追加し、`evt.Use()` 後の参照安全性を保証
