### PR TITLE
feat: add Japanese localization via NDMF (Component Manager)

### DIFF
--- a/Editor/ComponentManager.cs
+++ b/Editor/ComponentManager.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Kanameliser.EditorPlus
 {
     /// <summary>
-    /// ComponentManager：指定したオブジェクトとその子オブジェクトのコンポーネントを一覧表示して削除できる
+    /// ComponentManager: lists components of the specified object and its children, allowing bulk removal
     /// </summary>
     public class ComponentManager : EditorWindow
     {
@@ -19,7 +19,7 @@ namespace Kanameliser.EditorPlus
         private bool searchInPaths = false;
         private bool showAllComponentsOnMatch = false;
 
-        // データ管理とUI描画のクラス
+        // Data management and UI rendering helpers
         private ComponentDataManager dataManager;
         private ComponentUIRenderer uiRenderer;
 
@@ -33,6 +33,7 @@ namespace Kanameliser.EditorPlus
         {
             dataManager = new ComponentDataManager();
             uiRenderer = new ComponentUIRenderer(dataManager);
+            Localization.RegisterLanguageChangeCallback(this, w => w.Repaint());
         }
 
         // Exception policy:
@@ -46,18 +47,20 @@ namespace Kanameliser.EditorPlus
         {
             try
             {
-                // ウィンドウ幅に基づいてカラム幅を調整
+                // Adjust column widths based on the window width
                 uiRenderer.AdjustColumnWidths(EditorGUIUtility.currentViewWidth);
+
+                Localization.ShowLanguageUI();
 
                 GUILayout.Label("Component Manager", EditorStyles.boldLabel);
 
                 EditorGUILayout.Space();
 
-                // ターゲットオブジェクトフィールドを描画
+                // Draw the target object field
                 GameObject previousTarget = targetObject;
                 targetObject = uiRenderer.DrawTargetObjectField(targetObject, dataManager);
 
-                // ターゲットオブジェクト変更時のリスト更新
+                // Refresh the list when the target object changes
                 if (previousTarget != targetObject && targetObject != null)
                 {
                     dataManager.RefreshComponentsList(targetObject);
@@ -65,11 +68,11 @@ namespace Kanameliser.EditorPlus
 
                 EditorGUILayout.Space();
 
-                // フィルター入力欄を描画
+                // Draw the filter fields
                 var (newGameObjectFilter, newComponentFilter, newSearchInPaths, newShowAllComponentsOnMatch, newShowEmptyObjects) =
                     uiRenderer.DrawFilters(gameObjectFilter, componentFilter, searchInPaths, showAllComponentsOnMatch, showEmptyObjects);
 
-                // フィルター設定が変更された場合は更新
+                // Apply filter setting changes
                 bool filtersChanged = newGameObjectFilter != gameObjectFilter ||
                                      newComponentFilter != componentFilter ||
                                      newSearchInPaths != searchInPaths ||
@@ -85,7 +88,7 @@ namespace Kanameliser.EditorPlus
                     showAllComponentsOnMatch = newShowAllComponentsOnMatch;
                     showEmptyObjects = newShowEmptyObjects;
 
-                    // showEmptyObjectsが変更された場合は、リストを更新
+                    // Refresh the list when showEmptyObjects changed
                     if (emptyObjectsSettingChanged && targetObject != null)
                     {
                         dataManager.RefreshComponentsList(targetObject);
@@ -98,7 +101,7 @@ namespace Kanameliser.EditorPlus
                 {
                     DrawTableLayout();
 
-                    // リサイズ中は次のフレームでも再描画を要求
+                    // Request a repaint on the next frame while resizing
                     if (uiRenderer.IsResizingGameObjectColumn)
                     {
                         Repaint();
@@ -106,7 +109,7 @@ namespace Kanameliser.EditorPlus
                 }
                 else
                 {
-                    EditorGUILayout.HelpBox("Please select a GameObject to display components", MessageType.Info);
+                    EditorGUILayout.HelpBox(Localization.S("componentManager.selectPrompt"), MessageType.Info);
                 }
 
                 EditorGUILayout.Space();
@@ -120,20 +123,20 @@ namespace Kanameliser.EditorPlus
 
         private void DrawTableLayout()
         {
-            // テーブルヘッダー上部の区切り線
+            // Divider above the table header
             GUILayout.Box("", GUILayout.ExpandWidth(true), GUILayout.Height(1));
 
-            // 固定レイアウトのヘッダー行
+            // Fixed-layout header row
             Rect totalRect = EditorGUILayout.GetControlRect(GUILayout.ExpandWidth(true));
 
-            // フィルター後の表示対象となるGameObjectとComponent
+            // GameObjects and components to display after filtering
             var (filteredGameObjects, filteredComponents) = dataManager.GetFilteredItems(
                 targetObject, gameObjectFilter, componentFilter, searchInPaths, showAllComponentsOnMatch);
 
-            // テーブルヘッダーを描画
+            // Draw the table header
             uiRenderer.DrawTableHeader(totalRect, filteredGameObjects, filteredComponents);
 
-            // リサイズハンドルの処理
+            // Handle the resize handle
             Rect resizeHandleRect = new Rect(
                 totalRect.x + ComponentConstants.CHECKBOX_WIDTH + uiRenderer.GameObjectColumnWidth,
                 totalRect.y,
@@ -141,29 +144,29 @@ namespace Kanameliser.EditorPlus
                 totalRect.height);
             uiRenderer.HandleColumnResize(resizeHandleRect);
 
-            // ヘッダー下部の区切り線
+            // Divider below the header
             GUILayout.Box("", GUILayout.ExpandWidth(true), GUILayout.Height(1));
 
-            // スクロール可能なコンテンツ領域
+            // Scrollable content area
             scrollPosition = EditorGUILayout.BeginScrollView(scrollPosition);
 
 
-            // フィルターされたGameObjectを描画
+            // Draw the filtered GameObjects
             foreach (var gameObject in filteredGameObjects)
             {
                 if (gameObject == null) continue;
 
-                // このGameObjectに関連するフィルター済みコンポーネントのリスト
+                // Filtered components belonging to this GameObject
                 var components = dataManager.ComponentsByGameObject[gameObject];
 
-                // コンポーネントフィルタリングを共通メソッドを使用して実行
+                // Apply component filtering via the shared method
                 List<ComponentInfo> gameObjectFilteredComponents = dataManager.FilterComponentsByName(
                     components, componentFilter, showAllComponentsOnMatch);
 
-                // 統合された行を描画（GameObjectとそのコンポーネント）
+                // Draw the combined row (GameObject and its components)
                 uiRenderer.DrawCombinedRow(gameObject, gameObjectFilteredComponents, targetObject);
 
-                // 区切り線
+                // Divider
                 EditorGUILayout.Space();
                 Rect rect = EditorGUILayout.GetControlRect(false, 1);
                 EditorGUI.DrawRect(rect, new Color(0.5f, 0.5f, 0.5f, 1));
@@ -177,24 +180,24 @@ namespace Kanameliser.EditorPlus
         {
             EditorGUILayout.BeginHorizontal();
 
-            // 選択されたGameObjectとコンポーネントを取得
+            // Get the selected GameObjects and components
             var (selectedGameObjects, selectedComponents) = dataManager.GetSelectedItems();
 
-            // GameObjectまたはComponentが選択されているかチェック
+            // Check whether any GameObject or component is selected
             bool anyGameObjectSelected = selectedGameObjects.Count > 0;
             bool anyComponentSelected = selectedComponents.Count > 0;
 
-            // 選択ボタン - 条件に基づいて有効/無効を制御
+            // Select button - enabled/disabled based on conditions
             bool canSelect = CanSelectInHierarchy() && (anyGameObjectSelected || anyComponentSelected);
             GUI.enabled = canSelect;
-            if (GUILayout.Button("Select in Hierarchy", GUILayout.Height(30)))
+            if (GUILayout.Button(Localization.S("componentManager.selectInHierarchy"), GUILayout.Height(30)))
             {
                 SelectInHierarchy();
             }
 
-            // 削除ボタン
+            // Remove button
             GUI.enabled = anyGameObjectSelected || anyComponentSelected;
-            if (GUILayout.Button("Remove Selected Items", GUILayout.Height(30)))
+            if (GUILayout.Button(Localization.S("componentManager.removeSelectedItems"), GUILayout.Height(30)))
             {
                 RemoveSelectedComponents();
             }
@@ -204,35 +207,35 @@ namespace Kanameliser.EditorPlus
             EditorGUILayout.EndHorizontal();
         }
 
-        // Hierarchy内での選択が可能かどうかを判定
+        // Determine whether selecting in the Hierarchy is possible
         private bool CanSelectInHierarchy()
         {
             if (targetObject == null) return false;
 
-            // 現在のPrefab編集モード情報を取得
+            // Get the current prefab editing mode info
             var prefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
             bool isPrefabMode = prefabStage != null;
 
-            // ケース1: オブジェクトがシーン内オブジェクト（Hierarchy上のオブジェクト）
+            // Case 1: the object is a scene object (an object in the Hierarchy)
             bool isSceneObject = !PrefabUtility.IsPartOfPrefabAsset(targetObject) &&
                                !EditorUtility.IsPersistent(targetObject);
 
-            // ケース2: Prefab編集モードで開いているPrefabと同じPrefabがAssetsから指定された
+            // Case 2: a prefab asset matching the prefab open in prefab editing mode was specified from Assets
             bool isPrefabAssetMatchingCurrentStage = false;
             if (isPrefabMode && PrefabUtility.IsPartOfPrefabAsset(targetObject))
             {
-                // 編集中のPrefabアセットとターゲットオブジェクトのPrefabアセットが同じか確認
+                // Check whether the prefab asset being edited matches the target object's prefab asset
                 GameObject prefabAsset = PrefabUtility.GetCorrespondingObjectFromSource(prefabStage.prefabContentsRoot);
                 GameObject targetPrefabAsset = targetObject;
                 isPrefabAssetMatchingCurrentStage = (prefabAsset == targetPrefabAsset);
             }
 
-            // いずれかの条件を満たせば選択可能
+            // Selectable when either condition is met
             return isSceneObject || isPrefabAssetMatchingCurrentStage;
         }
 
         /// <summary>
-        /// Prefab編集モード内の対応するGameObjectを取得
+        /// Gets the corresponding GameObject inside prefab editing mode
         /// </summary>
         private GameObject GetCorrespondingPrefabModeObject(GameObject gameObject, UnityEditor.SceneManagement.PrefabStage prefabStage)
         {
@@ -245,48 +248,48 @@ namespace Kanameliser.EditorPlus
             return childTransform != null ? childTransform.gameObject : gameObject;
         }
 
-        // ヒエラルキー内で選択する処理
+        // Select objects in the Hierarchy
         private void SelectInHierarchy()
         {
             if (targetObject == null) return;
 
-            // 選択されたGameObjectとコンポーネントを取得
+            // Get the selected GameObjects and components
             var (selectedGameObjects, selectedComponents) = dataManager.GetSelectedItems();
 
-            // 選択用オブジェクトリスト
+            // Objects to select
             List<UnityEngine.Object> objectsToSelect = new List<UnityEngine.Object>();
 
-            // 現在のPrefab編集モード情報を取得
+            // Get the current prefab editing mode info
             var prefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
 
-            // チェックされたGameObjectを収集
+            // Collect the checked GameObjects
             foreach (var gameObject in selectedGameObjects)
             {
                 if (gameObject == null) continue;
 
-                // Prefab編集モードの場合、対応するPrefab編集モード内のオブジェクトを取得
+                // In prefab editing mode, get the corresponding object inside the prefab stage
                 GameObject objectToAdd = GetCorrespondingPrefabModeObject(gameObject, prefabStage);
                 objectsToSelect.Add(objectToAdd);
             }
 
-            // コンポーネントのチェック状態を確認し、対応するGameObjectを追加
+            // Check component selection states and add their GameObjects
             foreach (var compInfo in selectedComponents)
             {
                 if (compInfo == null || compInfo.GameObject == null) continue;
 
                 GameObject gameObject = compInfo.GameObject;
-                if (!selectedGameObjects.Contains(gameObject)) // GameObjectが直接選択されていない場合のみ
+                if (!selectedGameObjects.Contains(gameObject)) // Only when the GameObject itself is not selected
                 {
-                    // Prefab編集モードの場合、対応するPrefab編集モード内のオブジェクトを取得
+                    // In prefab editing mode, get the corresponding object inside the prefab stage
                     GameObject objectToAdd = GetCorrespondingPrefabModeObject(gameObject, prefabStage);
                     objectsToSelect.Add(objectToAdd);
                 }
             }
 
-            // 重複を除去
+            // Remove duplicates
             objectsToSelect = objectsToSelect.Distinct().ToList();
 
-            // ヒエラルキーで選択
+            // Select in the Hierarchy
             if (objectsToSelect.Count > 0)
             {
                 Selection.objects = objectsToSelect.ToArray();
@@ -294,55 +297,55 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// 選択されたアイテムの削除確認メッセージを作成
+        /// Builds the deletion confirmation message for the selected items
         /// </summary>
         private string CreateDeleteConfirmMessage(List<GameObject> selectedGameObjects, List<ComponentInfo> selectedComponents)
         {
-            string confirmMessage = "Are you sure you want to delete the following items?\n\n";
+            string confirmMessage = Localization.S("componentManager.confirmDeletion.header") + "\n\n";
 
-            // 選択されたGameObjectの一覧を追加
+            // Append the list of selected GameObjects
             if (selectedGameObjects.Count > 0)
             {
-                confirmMessage += "【Selected GameObjects】\n";
+                confirmMessage += Localization.S("componentManager.confirmDeletion.selectedGameObjects") + "\n";
                 for (int i = 0; i < selectedGameObjects.Count; i++)
                 {
                     if (selectedGameObjects[i] == null) continue;
 
-                    if (i < 10 || i == selectedGameObjects.Count - 1) // 最初の10個と最後の1個を表示
+                    if (i < 10 || i == selectedGameObjects.Count - 1) // Show the first 10 items and the last one
                     {
                         confirmMessage += "- " + ComponentPathUtility.GetGameObjectPath(selectedGameObjects[i], targetObject) + "\n";
                     }
-                    else if (i == 10) // 省略表示
+                    else if (i == 10) // Ellipsis
                     {
-                        confirmMessage += "- ... (and " + (selectedGameObjects.Count - 10) + " more GameObjects)\n";
+                        confirmMessage += Localization.S("componentManager.confirmDeletion.moreGameObjects", selectedGameObjects.Count - 10) + "\n";
                         break;
                     }
                 }
                 confirmMessage += "\n";
             }
 
-            // 選択されたコンポーネントの一覧を追加
+            // Append the list of selected components
             if (selectedComponents.Count > 0)
             {
-                confirmMessage += "【Selected Components】\n";
+                confirmMessage += Localization.S("componentManager.confirmDeletion.selectedComponents") + "\n";
                 for (int i = 0; i < selectedComponents.Count; i++)
                 {
                     if (selectedComponents[i] == null || selectedComponents[i].GameObject == null) continue;
 
-                    if (i < 10 || i == selectedComponents.Count - 1) // 最初の10個と最後の1個を表示
+                    if (i < 10 || i == selectedComponents.Count - 1) // Show the first 10 items and the last one
                     {
                         var comp = selectedComponents[i];
                         confirmMessage += "- " + ComponentPathUtility.GetGameObjectPath(comp.GameObject, targetObject) + " : " + comp.Name + "\n";
                     }
-                    else if (i == 10) // 省略表示
+                    else if (i == 10) // Ellipsis
                     {
-                        confirmMessage += "- ... (and " + (selectedComponents.Count - 10) + " more Components)\n";
+                        confirmMessage += Localization.S("componentManager.confirmDeletion.moreComponents", selectedComponents.Count - 10) + "\n";
                         break;
                     }
                 }
             }
 
-            confirmMessage += "\nUndo is available.";
+            confirmMessage += "\n" + Localization.S("componentManager.confirmDeletion.undoAvailable");
             return confirmMessage;
         }
 
@@ -350,33 +353,33 @@ namespace Kanameliser.EditorPlus
         {
             try
             {
-                // 選択されたGameObjectとコンポーネントを取得
+                // Get the selected GameObjects and components
                 var (selectedGameObjects, selectedComponents) = dataManager.GetSelectedItems();
 
                 if (selectedGameObjects.Count == 0 && selectedComponents.Count == 0) return;
 
-                // 確認ダイアログに表示するメッセージを作成
+                // Build the message shown in the confirmation dialog
                 string confirmMessage = CreateDeleteConfirmMessage(selectedGameObjects, selectedComponents);
 
-                // 確認ダイアログを表示
+                // Show the confirmation dialog
                 bool confirmResult = EditorUtility.DisplayDialog(
-                    "Confirm Deletion",
+                    Localization.S("componentManager.confirmDeletion"),
                     confirmMessage,
-                    "Delete",
-                    "Cancel"
+                    Localization.S("common.delete"),
+                    Localization.S("common.cancel")
                 );
 
-                // ユーザーが「削除する」を選んだ場合のみ処理を実行
+                // Proceed only when the user chose to delete
                 if (confirmResult)
                 {
-                    // 処理を Undo でまとめる
+                    // Group the operations into a single Undo step
                     Undo.SetCurrentGroupName("Remove GameObjects and Components");
                     int undoGroup = Undo.GetCurrentGroup();
                     List<string> failedItems = new List<string>();
 
                     try
                     {
-                        // 選択されたGameObjectを削除
+                        // Delete the selected GameObjects
                         foreach (var gameObject in selectedGameObjects)
                         {
                             if (gameObject == null) continue;
@@ -393,7 +396,7 @@ namespace Kanameliser.EditorPlus
                             }
                         }
 
-                        // 選択されたコンポーネントを削除
+                        // Delete the selected components
                         foreach (var componentInfo in selectedComponents)
                         {
                             if (componentInfo == null || componentInfo.Component == null) continue;
@@ -426,9 +429,9 @@ namespace Kanameliser.EditorPlus
                     if (failedItems.Count > 0)
                     {
                         EditorUtility.DisplayDialog(
-                            "Deletion Partially Completed",
-                            $"Some selected items could not be deleted:\n\n{string.Join("\n", failedItems)}",
-                            "OK"
+                            Localization.S("componentManager.deletionPartiallyCompleted"),
+                            Localization.S("componentManager.deletionPartiallyCompleted.message", string.Join("\n", failedItems)),
+                            Localization.S("common.ok")
                         );
                     }
                 }

--- a/Editor/ComponentManager/ComponentConstants.cs
+++ b/Editor/ComponentManager/ComponentConstants.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Kanameliser.EditorPlus
 {
     /// <summary>
-    /// 共通の定数を定義するクラス
+    /// Defines shared constants
     /// </summary>
     public static class ComponentConstants
     {

--- a/Editor/ComponentManager/ComponentDataManager.cs
+++ b/Editor/ComponentManager/ComponentDataManager.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Kanameliser.EditorPlus
 {
     /// <summary>
-    /// コンポーネントデータを管理するクラス
+    /// Manages component data
     /// </summary>
     public class ComponentDataManager
     {
@@ -20,7 +20,7 @@ namespace Kanameliser.EditorPlus
         public bool ShowEmptyObjects { get => showEmptyObjects; set => showEmptyObjects = value; }
 
         /// <summary>
-        /// コンポーネントリストを更新する
+        /// Refreshes the component list
         /// </summary>
         public void RefreshComponentsList(GameObject targetObject)
         {
@@ -33,7 +33,7 @@ namespace Kanameliser.EditorPlus
 
             try
             {
-                // ターゲットとその子オブジェクトを収集
+                // Collect the target and its child objects
                 Transform[] transforms = targetObject.GetComponentsInChildren<Transform>(true);
                 foreach (Transform transform in transforms)
                 {
@@ -42,10 +42,10 @@ namespace Kanameliser.EditorPlus
                     GameObject gameObject = transform.gameObject;
                     if (gameObject == null) continue;
 
-                    // オブジェクトのコンポーネントを収集
+                    // Collect the object's components
                     Component[] components = gameObject.GetComponents<Component>();
 
-                    // Transform以外のコンポーネントをフィルタリング
+                    // Filter out Transform components
                     List<ComponentInfo> componentInfos = components
                         .Where(c => c != null && !(c is Transform))
                         .Select(c => new ComponentInfo
@@ -56,10 +56,10 @@ namespace Kanameliser.EditorPlus
                         })
                         .ToList();
 
-                    // コンポーネントがないオブジェクトも表示するオプションがオンの場合
+                    // When the option to show GameObjects without components is on
                     if (componentInfos.Count > 0 || showEmptyObjects)
                     {
-                        // コンポーネントがなくてもGameObjectを登録
+                        // Register the GameObject even when it has no components
                         componentsByGameObject[gameObject] = componentInfos;
                         gameObjectSelectionState[gameObject] = false;
                     }
@@ -72,14 +72,14 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// 階層順にソートされたGameObjectのリストを取得
+        /// Gets the list of GameObjects sorted in hierarchy order
         /// </summary>
         public List<GameObject> GetOrderedGameObjects(GameObject targetObject)
         {
             List<GameObject> ordered = new List<GameObject>();
             if (targetObject == null) return ordered;
 
-            // GameObjectの順番を取得
+            // Traverse GameObjects in order
             Queue<Transform> queue = new Queue<Transform>();
             queue.Enqueue(targetObject.transform);
 
@@ -91,14 +91,14 @@ namespace Kanameliser.EditorPlus
                 GameObject currentGO = currentTransform.gameObject;
                 if (currentGO == null) continue;
 
-                // 辞書に存在するGameObjectのみを対象とする
-                // （コンポーネントがないオブジェクトも表示するオプションがオンの場合は辞書に含まれている）
+                // Only include GameObjects present in the dictionary
+                // (GameObjects without components are included when the corresponding option is on)
                 if (componentsByGameObject.ContainsKey(currentGO))
                 {
                     ordered.Add(currentGO);
                 }
 
-                // 子要素をキューに追加
+                // Enqueue child elements
                 for (int i = 0; i < currentTransform.childCount; i++)
                 {
                     Transform child = currentTransform.GetChild(i);
@@ -113,7 +113,7 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// GameObject名またはパスによるフィルタリングを行う
+        /// Filters by GameObject name or path
         /// </summary>
         private bool IsGameObjectMatchingFilter(GameObject gameObject, GameObject targetObject, string gameObjectFilter, bool searchInPaths)
         {
@@ -126,19 +126,19 @@ namespace Kanameliser.EditorPlus
 
             if (searchInPaths)
             {
-                // パスを含めて検索
+                // Search including the path
                 string path = ComponentPathUtility.GetGameObjectPath(gameObject, targetObject);
                 return path.ToLower().Contains(filterLower);
             }
             else
             {
-                // 名前のみで検索
+                // Search by name only
                 return gameObject.name.ToLower().Contains(filterLower);
             }
         }
 
         /// <summary>
-        /// コンポーネント名によるフィルタリングを行う
+        /// Filters components by name
         /// </summary>
         public List<ComponentInfo> FilterComponentsByName(List<ComponentInfo> components, string componentFilter, bool showAllComponentsOnMatch)
         {
@@ -149,19 +149,19 @@ namespace Kanameliser.EditorPlus
 
             string filterLower = componentFilter.ToLower();
 
-            // コンポーネント名でフィルタリング
+            // Filter by component name
             var matchingComponents = components
                 .Where(c => c.Name.ToLower().Contains(filterLower))
                 .ToList();
 
-            // 一致するコンポーネントを持つGameObjectの全コンポーネントを表示するオプション
+            // Option to show all components of GameObjects that have a matching component
             return (showAllComponentsOnMatch && matchingComponents.Any())
                 ? components.ToList()
                 : matchingComponents;
         }
 
         /// <summary>
-        /// フィルタリングされたGameObjectとコンポーネントを取得
+        /// Gets the filtered GameObjects and components
         /// </summary>
         public (List<GameObject> gameObjects, List<ComponentInfo> components) GetFilteredItems(
             GameObject targetObject, string gameObjectFilter, string componentFilter,
@@ -172,19 +172,19 @@ namespace Kanameliser.EditorPlus
 
             var orderedGameObjects = GetOrderedGameObjects(targetObject);
 
-            // GameObjectとコンポーネントのフィルタリング
+            // Filter GameObjects and components
             foreach (var gameObject in orderedGameObjects)
             {
                 if (!componentsByGameObject.ContainsKey(gameObject)) continue;
 
-                // GameObject名またはパスによるフィルタリング
+                // Filter by GameObject name or path
                 bool gameObjectMatched = IsGameObjectMatchingFilter(gameObject, targetObject, gameObjectFilter, searchInPaths);
                 if (!gameObjectMatched) continue;
 
                 var components = componentsByGameObject[gameObject];
                 var matchingComponents = FilterComponentsByName(components, componentFilter, showAllComponentsOnMatch);
 
-                // フィルタリング結果に基づいて表示対象を決定
+                // Decide what to display based on the filtering results
                 if (string.IsNullOrEmpty(componentFilter) || matchingComponents.Any())
                 {
                     filteredGameObjects.Add(gameObject);
@@ -196,16 +196,16 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// 選択されたGameObjectとコンポーネントを取得
+        /// Gets the selected GameObjects and components
         /// </summary>
         public (List<GameObject> gameObjects, List<ComponentInfo> components) GetSelectedItems()
         {
-            // 選択されたGameObjectを取得
+            // Get the selected GameObjects
             var selectedGameObjects = componentsByGameObject.Keys
                 .Where(go => gameObjectSelectionState.ContainsKey(go) && gameObjectSelectionState[go])
                 .ToList();
 
-            // 選択されたコンポーネントを取得（GameObjectが選択されていないもののみ）
+            // Get the selected components (only those whose GameObject is not selected)
             var selectedComponents = componentsByGameObject
                 .Where(entry => !gameObjectSelectionState.ContainsKey(entry.Key) || !gameObjectSelectionState[entry.Key])
                 .SelectMany(entry => entry.Value.Where(c => c.IsSelected))

--- a/Editor/ComponentManager/ComponentInfo.cs
+++ b/Editor/ComponentManager/ComponentInfo.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Kanameliser.EditorPlus
 {
     /// <summary>
-    /// コンポーネント情報を格納するクラス
+    /// Holds component information
     /// </summary>
     public class ComponentInfo
     {

--- a/Editor/ComponentManager/ComponentPathUtility.cs
+++ b/Editor/ComponentManager/ComponentPathUtility.cs
@@ -7,15 +7,15 @@ using UnityEngine;
 namespace Kanameliser.EditorPlus
 {
     /// <summary>
-    /// パス関連のユーティリティクラス
+    /// Path-related utility class
     /// </summary>
     public static class ComponentPathUtility
     {
-        // パスのキャッシュ
+        // Path cache
         private static Dictionary<(GameObject, GameObject), string> pathCache = new Dictionary<(GameObject, GameObject), string>();
 
         /// <summary>
-        /// パスキャッシュをクリア
+        /// Clears the path cache
         /// </summary>
         public static void ClearCache()
         {
@@ -23,7 +23,7 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// GameObjectのパスを取得（キャッシュ利用）
+        /// Gets the GameObject path (using the cache)
         /// </summary>
         public static string GetGameObjectPath(GameObject go, GameObject targetObject)
         {
@@ -31,7 +31,7 @@ namespace Kanameliser.EditorPlus
 
             var cacheKey = (go, targetObject);
 
-            // キャッシュにパスが存在する場合はそれを返す
+            // Return the cached path when available
             if (pathCache.TryGetValue(cacheKey, out string cachedPath))
             {
                 return cachedPath;
@@ -39,14 +39,14 @@ namespace Kanameliser.EditorPlus
 
             string path = CalculateGameObjectPath(go, targetObject);
 
-            // キャッシュに保存
+            // Store in the cache
             pathCache[cacheKey] = path;
 
             return path;
         }
 
         /// <summary>
-        /// 実際のパス計算
+        /// Performs the actual path calculation
         /// </summary>
         private static string CalculateGameObjectPath(GameObject go, GameObject targetObject)
         {
@@ -54,27 +54,27 @@ namespace Kanameliser.EditorPlus
 
             try
             {
-                // targetObjectがnullの場合は、従来通りの完全パスを返す
+                // When targetObject is null, return the conventional full path
                 if (targetObject == null)
                 {
                     return GetFullPath(go);
                 }
 
-                // 対象がtargetObject自身の場合は、targetObjectの名前を返す
+                // When the object is targetObject itself, return targetObject's name
                 if (go == targetObject)
                 {
                     return targetObject.name;
                 }
 
-                // targetObjectからの相対パスを構築する
+                // Build the path relative to targetObject
                 if (IsChildOf(go.transform, targetObject.transform))
                 {
-                    // goがtargetObjectの子孫である場合
+                    // go is a descendant of targetObject
                     return targetObject.name + "/" + GetRelativePathFromAncestor(go.transform, targetObject.transform);
                 }
                 else if (IsChildOf(targetObject.transform, go.transform))
                 {
-                    // targetObjectがgoの子孫である場合
+                    // targetObject is a descendant of go
                     string upPath = "";
                     Transform parent = targetObject.transform.parent;
                     Transform goTransform = go.transform;
@@ -91,27 +91,27 @@ namespace Kanameliser.EditorPlus
                     }
                 }
 
-                // 共通の祖先を見つけて相対パスを構築
+                // Find the common ancestor and build a relative path
                 Transform commonAncestor = FindCommonAncestor(go.transform, targetObject.transform);
                 if (commonAncestor != null)
                 {
                     string upPath = "";
                     Transform current = targetObject.transform;
 
-                    // targetObjectから共通祖先までの上方向のパス
+                    // Upward path from targetObject to the common ancestor
                     while (current != null && current != commonAncestor)
                     {
                         upPath += "../";
                         current = current.parent;
                     }
 
-                    // 共通祖先からgoまでの下方向のパス
+                    // Downward path from the common ancestor to go
                     string downPath = GetRelativePathFromAncestor(go.transform, commonAncestor);
 
                     return targetObject.name + "/" + (upPath + downPath).TrimEnd('/');
                 }
 
-                // 関連性がない場合は完全パスを返す（ターゲットオブジェクト名を先頭に付ける）
+                // When unrelated, return the full path (prefixed with the target object's name)
                 return targetObject.name + " → " + GetFullPath(go);
             }
             catch (Exception ex)
@@ -121,7 +121,7 @@ namespace Kanameliser.EditorPlus
             }
         }
 
-        // あるTransformが別のTransformの子孫であるかチェック
+        // Check whether a Transform is a descendant of another Transform
         private static bool IsChildOf(Transform child, Transform parent)
         {
             if (child == null || parent == null) return false;
@@ -136,7 +136,7 @@ namespace Kanameliser.EditorPlus
             return false;
         }
 
-        // 祖先からの相対パスを取得
+        // Get the path relative to an ancestor
         public static string GetRelativePathFromAncestor(Transform descendant, Transform ancestor)
         {
             if (descendant == null || ancestor == null) return string.Empty;
@@ -156,12 +156,12 @@ namespace Kanameliser.EditorPlus
             return path;
         }
 
-        // 二つのTransform間の共通祖先を見つける
+        // Find the common ancestor of two Transforms
         private static Transform FindCommonAncestor(Transform t1, Transform t2)
         {
             if (t1 == null || t2 == null) return null;
 
-            // t1の全祖先を格納
+            // Store all ancestors of t1
             HashSet<Transform> t1Ancestors = new HashSet<Transform>();
             Transform current = t1;
 
@@ -171,7 +171,7 @@ namespace Kanameliser.EditorPlus
                 current = current.parent;
             }
 
-            // t2を辿りながら、t1の祖先セットと一致するものを探す
+            // Walk up from t2 looking for a match in t1's ancestor set
             current = t2;
             while (current != null)
             {
@@ -180,7 +180,7 @@ namespace Kanameliser.EditorPlus
                 current = current.parent;
             }
 
-            return null; // 共通祖先なし
+            return null; // No common ancestor
         }
 
         private static string GetFullPath(GameObject go)

--- a/Editor/ComponentManager/ComponentUIRenderer.cs
+++ b/Editor/ComponentManager/ComponentUIRenderer.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace Kanameliser.EditorPlus
 {
     /// <summary>
-    /// UI描画を担当するクラス
+    /// Handles UI rendering
     /// </summary>
     public class ComponentUIRenderer
     {
@@ -17,7 +17,7 @@ namespace Kanameliser.EditorPlus
         private bool isResizingGameObjectColumn = false;
         private float totalWidth = 0f;
 
-        // スタイル定義
+        // Style definitions
         private GUIStyle headerLabelStyle;
         private GUIStyle pathLabelStyle;
         private GUIStyle componentLabelStyle;
@@ -34,7 +34,7 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// UIスタイルを初期化
+        /// Initializes the UI styles
         /// </summary>
         private void InitializeStyles()
         {
@@ -52,39 +52,39 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// ウィンドウ幅に基づいてカラム幅を調整
+        /// Adjusts column widths based on the window width
         /// </summary>
         public void AdjustColumnWidths(float windowWidth)
         {
             totalWidth = windowWidth;
 
-            // 使用可能な全体幅からチェックボックスとリサイズハンドル幅を引く
+            // Subtract the checkbox and resize handle widths from the total available width
             float availableWidth = totalWidth - (ComponentConstants.CHECKBOX_WIDTH * 2) - ComponentConstants.RESIZE_HANDLE_WIDTH - ComponentConstants.COLUMN_MARGIN;
 
-            // GameObjectカラムとComponentカラムが両方とも最小幅以上になるよう調整
+            // Keep both the GameObject and Component columns at or above the minimum width
             float totalMinWidth = ComponentConstants.MIN_COLUMN_WIDTH * 2;
             if (availableWidth < totalMinWidth)
             {
-                // 利用可能な幅が足りない場合は、均等に分配
+                // Distribute evenly when the available width is insufficient
                 gameObjectColumnWidth = availableWidth / 2;
                 componentColumnWidth = availableWidth / 2;
             }
             else
             {
-                // GameObjectカラムの最大幅を全幅の60%以下に制限
+                // Cap the GameObject column width at 60% of the total width
                 float maxGameObjectWidth = availableWidth * ComponentConstants.MAX_COLUMN_RATIO;
                 gameObjectColumnWidth = Mathf.Min(gameObjectColumnWidth, maxGameObjectWidth);
 
-                // GameObjectカラムが最小幅を下回らないようにする
+                // Keep the GameObject column at or above the minimum width
                 gameObjectColumnWidth = Mathf.Max(gameObjectColumnWidth, ComponentConstants.MIN_COLUMN_WIDTH);
 
-                // componentColumnWidthはGameObjectカラム幅に応じて調整（最小幅を確保）
+                // Adjust componentColumnWidth based on the GameObject column width (ensuring the minimum width)
                 componentColumnWidth = Mathf.Max(availableWidth - gameObjectColumnWidth, ComponentConstants.MIN_COLUMN_WIDTH);
 
-                // 両方のカラム幅合計が利用可能幅を超える場合は調整
+                // Adjust when both column widths together exceed the available width
                 if (gameObjectColumnWidth + componentColumnWidth > availableWidth)
                 {
-                    // 比率を維持しながら調整
+                    // Adjust while preserving the ratio
                     float ratio = gameObjectColumnWidth / (gameObjectColumnWidth + componentColumnWidth);
                     gameObjectColumnWidth = availableWidth * ratio;
                     componentColumnWidth = availableWidth * (1 - ratio);
@@ -93,13 +93,13 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// テーブルヘッダーを描画
+        /// Draws the table header
         /// </summary>
         public void DrawTableHeader(Rect totalRect, List<GameObject> filteredGameObjects, List<ComponentInfo> filteredComponents)
         {
             float startX = totalRect.x;
 
-            // GameObject チェックボックス列
+            // GameObject checkbox column
             Rect checkboxRect1 = new Rect(startX, totalRect.y, ComponentConstants.CHECKBOX_WIDTH, totalRect.height);
             bool allGameObjectsSelected = filteredGameObjects.Count > 0 &&
                                          filteredGameObjects.All(go => dataManager.GameObjectSelectionState[go]);
@@ -111,30 +111,30 @@ namespace Kanameliser.EditorPlus
 
             if (newAllGameObjectsSelected != allGameObjectsSelected)
             {
-                // 混合状態でクリックされた場合は常に全解除する
+                // Always clear all when clicked in a mixed state
                 bool newState = newAllGameObjectsSelected;
                 if (mixedGameObjectSelection)
                 {
                     newState = false;
                 }
 
-                // GameObjectのみ選択状態を更新（コンポーネントは連動させない）
+                // Update selection state for GameObjects only (components are not linked)
                 foreach (var go in filteredGameObjects)
                 {
                     dataManager.GameObjectSelectionState[go] = newState;
                 }
             }
 
-            // GameObject ヘッダー
+            // GameObject header
             Rect gameObjectHeaderRect = new Rect(startX + ComponentConstants.CHECKBOX_WIDTH, totalRect.y, gameObjectColumnWidth, totalRect.height);
             EditorGUI.LabelField(gameObjectHeaderRect, "GameObject", headerLabelStyle);
 
-            // リサイズハンドル
+            // Resize handle
             Rect resizeHandleRect = new Rect(startX + ComponentConstants.CHECKBOX_WIDTH + gameObjectColumnWidth, totalRect.y, ComponentConstants.RESIZE_HANDLE_WIDTH, totalRect.height);
             EditorGUI.LabelField(resizeHandleRect, "|", EditorStyles.boldLabel);
             EditorGUIUtility.AddCursorRect(resizeHandleRect, MouseCursor.ResizeHorizontal);
 
-            // Component チェックボックス列
+            // Component checkbox column
             Rect checkboxRect2 = new Rect(startX + ComponentConstants.CHECKBOX_WIDTH + gameObjectColumnWidth + ComponentConstants.RESIZE_HANDLE_WIDTH, totalRect.y, ComponentConstants.CHECKBOX_WIDTH, totalRect.height);
             bool allComponentsSelected = filteredComponents.Count > 0 &&
                                         filteredComponents.All(c => c.IsSelected);
@@ -146,56 +146,56 @@ namespace Kanameliser.EditorPlus
 
             if (newAllComponentsSelected != allComponentsSelected)
             {
-                // 混合状態でクリックされた場合は常に全解除する
+                // Always clear all when clicked in a mixed state
                 bool newState = newAllComponentsSelected;
                 if (mixedComponentSelection)
                 {
                     newState = false;
                 }
 
-                // フィルター後の表示対象のみを更新
+                // Update only the items visible after filtering
                 foreach (var comp in filteredComponents)
                 {
                     comp.IsSelected = newState;
                 }
             }
 
-            // Component ヘッダー
+            // Component header
             Rect componentHeaderRect = new Rect(startX + ComponentConstants.CHECKBOX_WIDTH + gameObjectColumnWidth + ComponentConstants.RESIZE_HANDLE_WIDTH + ComponentConstants.CHECKBOX_WIDTH,
                                               totalRect.y, componentColumnWidth, totalRect.height);
             EditorGUI.LabelField(componentHeaderRect, "Component", headerLabelStyle);
         }
 
         /// <summary>
-        /// GameObjectとそのコンポーネントの行を描画
+        /// Draws a row for a GameObject and its components
         /// </summary>
         public void DrawCombinedRow(GameObject gameObj, List<ComponentInfo> components, GameObject targetObject)
         {
             if (gameObj == null) return;
 
-            // 行の高さを計算 (GameObject + コンポーネント数に基づく)
+            // Calculate the row height (based on the GameObject plus the component count)
             int componentCount = components.Count;
-            int calculatedRowHeight = Mathf.Max((int)ComponentConstants.MIN_ROW_HEIGHT, (int)(ComponentConstants.ROW_HEIGHT + componentCount * ComponentConstants.ROW_HEIGHT)); // 最低高さは36px
+            int calculatedRowHeight = Mathf.Max((int)ComponentConstants.MIN_ROW_HEIGHT, (int)(ComponentConstants.ROW_HEIGHT + componentCount * ComponentConstants.ROW_HEIGHT)); // Minimum height is 36px
 
             Rect totalRect = EditorGUILayout.GetControlRect(GUILayout.ExpandWidth(true), GUILayout.Height(calculatedRowHeight));
             float startX = totalRect.x;
 
-            // GameObject チェックボックス - GameObject名と同じ高さに配置
+            // GameObject checkbox - aligned with the GameObject name
             Rect goCheckboxRect = new Rect(startX, totalRect.y, ComponentConstants.CHECKBOX_WIDTH, ComponentConstants.ROW_HEIGHT);
             bool isGameObjectSelected = dataManager.GameObjectSelectionState[gameObj];
 
-            // EditorGUI.Toggleを使用して状態変更を検出
+            // Use EditorGUI.Toggle to detect state changes
             bool newIsGameObjectSelected = EditorGUI.Toggle(goCheckboxRect, isGameObjectSelected);
             if (newIsGameObjectSelected != isGameObjectSelected)
             {
                 dataManager.GameObjectSelectionState[gameObj] = newIsGameObjectSelected;
             }
 
-            // GameObject名
+            // GameObject name
             Rect nameRect = new Rect(startX + ComponentConstants.CHECKBOX_WIDTH, totalRect.y, gameObjectColumnWidth, ComponentConstants.ROW_HEIGHT);
             EditorGUI.LabelField(nameRect, gameObj.name, headerLabelStyle);
 
-            // GameObject名の部分をクリックできるように
+            // Make the GameObject name clickable
             Event evt = Event.current;
             if (evt.type == EventType.MouseDown && nameRect.Contains(evt.mousePosition))
             {
@@ -205,12 +205,12 @@ namespace Kanameliser.EditorPlus
                 EditorWindow.GetWindow<ComponentManager>().Repaint();
             }
 
-            // GameObject パス
+            // GameObject path
             Rect pathRect = new Rect(startX + ComponentConstants.CHECKBOX_WIDTH, totalRect.y + 18, gameObjectColumnWidth, 16);
             string path = ComponentPathUtility.GetGameObjectPath(gameObj, targetObject);
             EditorGUI.LabelField(pathRect, path, pathLabelStyle);
 
-            // パスの部分もクリックできるように
+            // Make the path clickable as well
             if (evt.type == EventType.MouseDown && pathRect.Contains(evt.mousePosition))
             {
                 Event evtCopy = new Event(evt);
@@ -219,10 +219,10 @@ namespace Kanameliser.EditorPlus
                 EditorWindow.GetWindow<ComponentManager>().Repaint();
             }
 
-            // コンポーネント部分
+            // Component area
             float componentStartX = startX + ComponentConstants.CHECKBOX_WIDTH + gameObjectColumnWidth + ComponentConstants.RESIZE_HANDLE_WIDTH;
 
-            // 各コンポーネントを描画（インデントなしで縦に並べる）
+            // Draw each component (stacked vertically without indentation)
             for (int i = 0; i < components.Count; i++)
             {
                 var component = components[i];
@@ -230,18 +230,18 @@ namespace Kanameliser.EditorPlus
 
                 float yOffset = i * ComponentConstants.ROW_HEIGHT;
 
-                // コンポーネントのチェックボックス
+                // Component checkbox
                 Rect compCheckboxRect = new Rect(componentStartX, totalRect.y + yOffset, ComponentConstants.CHECKBOX_WIDTH, ComponentConstants.ROW_HEIGHT);
                 bool isCompSelected = component.IsSelected;
 
-                // EditorGUI.Toggleを使用して状態変更を検出
+                // Use EditorGUI.Toggle to detect state changes
                 bool newIsCompSelected = EditorGUI.Toggle(compCheckboxRect, isCompSelected);
                 if (newIsCompSelected != isCompSelected)
                 {
                     component.IsSelected = newIsCompSelected;
                 }
 
-                // コンポーネントアイコン
+                // Component icon
                 GUIContent content = component.Component != null
                     ? EditorGUIUtility.ObjectContent(component.Component, component.Component.GetType())
                     : new GUIContent("Missing");
@@ -249,7 +249,7 @@ namespace Kanameliser.EditorPlus
                 Rect iconRect = new Rect(componentStartX + ComponentConstants.CHECKBOX_WIDTH, totalRect.y + yOffset, ComponentConstants.ICON_WIDTH, ComponentConstants.ROW_HEIGHT);
                 EditorGUI.LabelField(iconRect, new GUIContent(content.image));
 
-                // コンポーネント名
+                // Component name
                 Rect compLabelRect = new Rect(componentStartX + ComponentConstants.CHECKBOX_WIDTH + ComponentConstants.ICON_WIDTH, totalRect.y + yOffset,
                                    componentColumnWidth - ComponentConstants.ICON_WIDTH, ComponentConstants.ROW_HEIGHT);
                 EditorGUI.LabelField(compLabelRect, component.Name, componentLabelStyle);
@@ -257,7 +257,7 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// リサイズハンドルの処理
+        /// Handles the column resize handle
         /// </summary>
         public void HandleColumnResize(Rect resizeHandleRect)
         {
@@ -265,7 +265,7 @@ namespace Kanameliser.EditorPlus
 
             EditorGUIUtility.AddCursorRect(resizeHandleRect, MouseCursor.ResizeHorizontal);
 
-            // リサイズハンドルの処理をイベントタイプごとに分離
+            // Handle the resize handle separately per event type
             switch (evt.type)
             {
                 case EventType.MouseDown:
@@ -307,27 +307,27 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// カラム幅を更新する
+        /// Updates the column widths
         /// </summary>
         private void UpdateColumnWidths(float deltaX)
         {
             float availableWidth = totalWidth - (ComponentConstants.CHECKBOX_WIDTH * 2) - ComponentConstants.RESIZE_HANDLE_WIDTH - ComponentConstants.COLUMN_MARGIN;
 
-            // 新しい幅を計算
+            // Calculate the new width
             float newWidth = gameObjectColumnWidth + deltaX;
 
-            // 最小幅を確保しつつ、最大幅をウィンドウの60%以下に制限
+            // Ensure the minimum width while capping the maximum at 60% of the window
             float maxAllowed = Mathf.Max(availableWidth * ComponentConstants.MAX_COLUMN_RATIO, ComponentConstants.MIN_COLUMN_WIDTH);
             newWidth = Mathf.Clamp(newWidth, ComponentConstants.MIN_COLUMN_WIDTH, maxAllowed);
 
-            // コンポーネント列も最小幅を下回らないようにする
+            // Keep the component column from going below the minimum width as well
             float remainingWidth = availableWidth - newWidth;
             if (remainingWidth < ComponentConstants.MIN_COLUMN_WIDTH)
             {
                 newWidth = availableWidth - ComponentConstants.MIN_COLUMN_WIDTH;
             }
 
-            // 変更があればレイアウトを更新
+            // Update the layout when changed
             if (newWidth != gameObjectColumnWidth)
             {
                 gameObjectColumnWidth = newWidth;
@@ -336,23 +336,23 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// GameObjectをHierarchy上で選択する
+        /// Selects the GameObject in the Hierarchy
         /// </summary>
         private void SelectGameObjectInHierarchy(GameObject gameObj, GameObject targetObject)
         {
             if (gameObj == null) return;
 
-            // 現在のPrefab編集モード情報を取得
+            // Get the current prefab editing mode info
             var prefabStage = UnityEditor.SceneManagement.PrefabStageUtility.GetCurrentPrefabStage();
 
-            // Prefab編集モードの場合、対応するPrefab編集モード内のオブジェクトを取得
+            // In prefab editing mode, get the corresponding object inside the prefab stage
             GameObject objectToSelect = GetCorrespondingPrefabModeObject(gameObj, prefabStage, targetObject);
 
-            // ヒエラルキーで選択
+            // Select in the Hierarchy
             Selection.activeObject = objectToSelect;
 
-            // エディタのフォーカスをHierarchyビューに移す
-            // まずSceneHierarchyWindowを取得してみる
+            // Move editor focus to the Hierarchy view
+            // Try to get the SceneHierarchyWindow first
             var sceneHierarchyWindowType = System.Type.GetType("UnityEditor.SceneHierarchyWindow,UnityEditor");
             if (sceneHierarchyWindowType != null)
             {
@@ -364,29 +364,29 @@ namespace Kanameliser.EditorPlus
                 }
             }
 
-            // フォールバック
+            // Fallback
             EditorApplication.ExecuteMenuItem("Window/General/Hierarchy");
         }
 
         /// <summary>
-        /// Prefab編集モード内の対応するGameObjectを取得
+        /// Gets the corresponding GameObject inside prefab editing mode
         /// </summary>
         private GameObject GetCorrespondingPrefabModeObject(GameObject gameObject, UnityEditor.SceneManagement.PrefabStage prefabStage, GameObject targetObject)
         {
             if (prefabStage == null)
                 return gameObject;
 
-            // 直接インスタンスIDで対応関係を確認
+            // Check the correspondence directly via instance IDs
             if (PrefabUtility.IsPartOfPrefabInstance(prefabStage.prefabContentsRoot) &&
                 PrefabUtility.IsPartOfPrefabInstance(gameObject))
             {
-                // 編集中のPrefabアセットとターゲットオブジェクトが同じPrefab階層にある可能性がある
+                // The prefab asset being edited and the target object may belong to the same prefab hierarchy
                 GameObject prefabAsset = PrefabUtility.GetCorrespondingObjectFromSource(prefabStage.prefabContentsRoot);
                 GameObject gameObjectPrefabAsset = PrefabUtility.GetOutermostPrefabInstanceRoot(gameObject);
 
                 if (prefabAsset == gameObjectPrefabAsset)
                 {
-                    // 同じPrefabの一部なので、相対パスを使用して対応するオブジェクトを見つける
+                    // Part of the same prefab, so find the corresponding object via the relative path
                     string relativePath = ComponentPathUtility.GetRelativePathFromAncestor(gameObject.transform, targetObject.transform);
                     if (!string.IsNullOrEmpty(relativePath))
                     {
@@ -397,7 +397,7 @@ namespace Kanameliser.EditorPlus
                 }
             }
 
-            // パス解決によるフォールバック
+            // Fallback via path resolution
             string path = ComponentPathUtility.GetRelativePathFromAncestor(gameObject.transform, targetObject.transform);
             if (!string.IsNullOrEmpty(path) && path != ".")
             {
@@ -406,10 +406,10 @@ namespace Kanameliser.EditorPlus
                     return childTransform.gameObject;
             }
 
-            // 同じ名前のオブジェクトを探す（最終手段）
+            // Search for an object with the same name (last resort)
             if (gameObject != targetObject)
             {
-                // 深さ優先探索でGameObjectをPrefabステージから探す
+                // Depth-first search for the GameObject within the prefab stage
                 return FindMatchingGameObjectInPrefab(gameObject.name, prefabStage.prefabContentsRoot);
             }
 
@@ -417,14 +417,14 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// 名前に基づいて一致するGameObjectをPrefab内で探す
+        /// Finds a matching GameObject in the prefab by name
         /// </summary>
         private GameObject FindMatchingGameObjectInPrefab(string objectName, GameObject root)
         {
             if (root.name == objectName)
                 return root;
 
-            // 子オブジェクトを再帰的に探索
+            // Search child objects recursively
             foreach (Transform child in root.transform)
             {
                 GameObject result = FindMatchingGameObjectInPrefab(objectName, child.gameObject);
@@ -436,51 +436,51 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// フィルター入力欄を描画
+        /// Draws the filter fields
         /// </summary>
         public (string gameObjectFilter, string componentFilter, bool searchInPaths, bool showAllComponentsOnMatch, bool showEmptyObjects)
             DrawFilters(string gameObjectFilter, string componentFilter, bool searchInPaths, bool showAllComponentsOnMatch, bool showEmptyObjects)
         {
-            // フィルター入力欄
+            // Filter fields
             EditorGUILayout.BeginHorizontal();
 
-            // チェックボックス分の空白
+            // Spacing for the checkbox column
             GUILayout.Space(ComponentConstants.CHECKBOX_WIDTH);
 
-            // GameObjectフィルター (GameObject列と同じ幅を使用、最小幅も設定)
+            // GameObject filter (uses the same width as the GameObject column, with a minimum width)
             EditorGUILayout.BeginVertical(GUILayout.Width(gameObjectColumnWidth), GUILayout.MinWidth(ComponentConstants.MIN_COLUMN_WIDTH));
-            EditorGUILayout.LabelField("GameObject Filter:", headerLabelStyle);
+            EditorGUILayout.LabelField(Localization.S("componentManager.gameObjectFilter"), headerLabelStyle);
             string newGameObjectFilter = EditorGUILayout.TextField(gameObjectFilter);
 
-            // GameObject フィルターオプション
-            bool newSearchInPaths = EditorGUILayout.ToggleLeft(" Include paths in search", searchInPaths);
+            // GameObject filter options
+            bool newSearchInPaths = EditorGUILayout.ToggleLeft(" " + Localization.S("componentManager.includePathsInSearch"), searchInPaths);
 
             EditorGUILayout.EndVertical();
 
-            // リサイズハンドル分の空白
+            // Spacing for the resize handle
             GUILayout.Space(ComponentConstants.RESIZE_HANDLE_WIDTH);
 
-            // チェックボックス分の空白
+            // Spacing for the checkbox column
             GUILayout.Space(ComponentConstants.CHECKBOX_WIDTH);
 
-            // Componentフィルター (残りの幅を使用、最小幅も設定)
+            // Component filter (uses the remaining width, with a minimum width)
             EditorGUILayout.BeginVertical(GUILayout.Width(componentColumnWidth), GUILayout.MinWidth(ComponentConstants.MIN_COLUMN_WIDTH));
-            EditorGUILayout.LabelField("Component Filter:", headerLabelStyle);
+            EditorGUILayout.LabelField(Localization.S("componentManager.componentFilter"), headerLabelStyle);
             string newComponentFilter = EditorGUILayout.TextField(componentFilter);
 
-            // コンポーネント フィルターオプション
-            bool newShowAllComponentsOnMatch = EditorGUILayout.ToggleLeft(" Show all components of matching GameObjects", showAllComponentsOnMatch);
+            // Component filter options
+            bool newShowAllComponentsOnMatch = EditorGUILayout.ToggleLeft(" " + Localization.S("componentManager.showAllComponentsOnMatch"), showAllComponentsOnMatch);
 
             EditorGUILayout.EndVertical();
 
             EditorGUILayout.EndHorizontal();
 
-            // 追加オプション（横並び）
+            // Additional options (laid out horizontally)
             EditorGUILayout.BeginHorizontal();
-            GUILayout.Space(ComponentConstants.CHECKBOX_WIDTH); // 左側の余白を合わせる
+            GUILayout.Space(ComponentConstants.CHECKBOX_WIDTH); // Match the left margin
 
-            // コンポーネントがないオブジェクトも表示するオプション
-            bool newShowEmptyObjects = EditorGUILayout.ToggleLeft(" Show GameObjects with no components", showEmptyObjects);
+            // Option to also show GameObjects without components
+            bool newShowEmptyObjects = EditorGUILayout.ToggleLeft(" " + Localization.S("componentManager.showEmptyObjects"), showEmptyObjects);
             if (newShowEmptyObjects != showEmptyObjects)
             {
                 dataManager.ShowEmptyObjects = newShowEmptyObjects;
@@ -488,7 +488,7 @@ namespace Kanameliser.EditorPlus
             }
             else
             {
-                // もしかするとdataManagerの値と一致していない可能性があるので同期する
+                // Sync in case the value differs from dataManager's
                 showEmptyObjects = dataManager.ShowEmptyObjects;
             }
 
@@ -498,24 +498,24 @@ namespace Kanameliser.EditorPlus
         }
 
         /// <summary>
-        /// ターゲットオブジェクトフィールドを描画
+        /// Draws the target object field
         /// </summary>
         public GameObject DrawTargetObjectField(GameObject targetObject, ComponentDataManager dataManager)
         {
             EditorGUILayout.BeginHorizontal();
 
-            EditorGUILayout.LabelField("Target Object", GUILayout.Width(EditorGUIUtility.labelWidth - 30));
+            EditorGUILayout.LabelField(Localization.S("componentManager.targetObject"), GUILayout.Width(EditorGUIUtility.labelWidth - 30));
 
-            // 更新ボタンを追加（ラベルの後、フィールドの前）
+            // Refresh button (after the label, before the field)
             if (GUILayout.Button(EditorGUIUtility.IconContent("Refresh"), GUILayout.Width(30), GUILayout.Height(18)))
             {
                 if (targetObject != null)
                 {
-                    // 現在のチェック状態を保存
+                    // Save the current selection states
                     Dictionary<GameObject, bool> savedGameObjectSelectionState = new Dictionary<GameObject, bool>(dataManager.GameObjectSelectionState);
                     Dictionary<Component, bool> savedComponentSelectionState = new Dictionary<Component, bool>();
 
-                    // 各コンポーネントの選択状態を保存
+                    // Save the selection state of each component
                     foreach (var entry in dataManager.ComponentsByGameObject)
                     {
                         foreach (var compInfo in entry.Value)
@@ -529,7 +529,7 @@ namespace Kanameliser.EditorPlus
 
                     dataManager.RefreshComponentsList(targetObject);
 
-                    // GameObjectのチェック状態を復元
+                    // Restore GameObject selection states
                     foreach (var gameObject in dataManager.GameObjectSelectionState.Keys.ToList())
                     {
                         if (savedGameObjectSelectionState.ContainsKey(gameObject))
@@ -538,7 +538,7 @@ namespace Kanameliser.EditorPlus
                         }
                     }
 
-                    // コンポーネントのチェック状態を復元
+                    // Restore component selection states
                     foreach (var entry in dataManager.ComponentsByGameObject)
                     {
                         foreach (var compInfo in entry.Value)
@@ -552,7 +552,7 @@ namespace Kanameliser.EditorPlus
                 }
             }
 
-            // オブジェクトフィールド
+            // Object field
             EditorGUI.BeginChangeCheck();
             GameObject newTargetObject = EditorGUILayout.ObjectField("", targetObject, typeof(GameObject), true) as GameObject;
             GameObject resultTargetObject = targetObject;

--- a/Editor/Kanameliser.EditorPlus.Editor.asmdef
+++ b/Editor/Kanameliser.EditorPlus.Editor.asmdef
@@ -22,6 +22,11 @@
             "define": "NDMF_INSTALLED"
         },
         {
+            "name": "nadena.dev.ndmf",
+            "expression": "[1.11.0,2.0.0)",
+            "define": "KEP_NDMF_LOCALIZATION"
+        },
+        {
             "name": "nadena.dev.modular-avatar",
             "expression": "1.13.0",
             "define": "MODULAR_AVATAR_INSTALLED"

--- a/Editor/Localization.meta
+++ b/Editor/Localization.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7e8ddb2ba9cc4f5d87b6f425b5237370
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Localization/Localization.cs
+++ b/Editor/Localization/Localization.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+
+#if KEP_NDMF_LOCALIZATION
+using nadena.dev.ndmf.localization;
+using nadena.dev.ndmf.ui;
+#endif
+
+namespace Kanameliser.EditorPlus
+{
+    internal static class Localization
+    {
+#if KEP_NDMF_LOCALIZATION
+        // ── NDMF path: full localization with language switching ──
+
+        private static readonly Localizer L = new Localizer("en-us", () => new List<LocalizationAsset>
+        {
+            AssetDatabase.LoadAssetAtPath<LocalizationAsset>(
+                "Packages/net.kanameliser.editor-plus/Editor/Localization/en-us.po"),
+            AssetDatabase.LoadAssetAtPath<LocalizationAsset>(
+                "Packages/net.kanameliser.editor-plus/Editor/Localization/ja-jp.po"),
+        });
+
+        public static string S(string key) =>
+            L.TryGetLocalizedString(key, out var val) ? val : key;
+
+        public static void ShowLanguageUI() => LanguageSwitcher.DrawImmediate();
+
+        public static void LocalizeUIElements(VisualElement root) =>
+            L.LocalizeUIElements(root);
+
+        public static void RegisterLanguageChangeCallback<T>(T owner, Action<T> callback)
+            where T : class =>
+            LanguagePrefs.RegisterLanguageChangeCallback(owner, callback);
+#else
+        // ── Fallback path: English only, no language switching ──
+
+        private static LocalizationAsset _enAsset;
+
+        private static LocalizationAsset EnAsset
+        {
+            get
+            {
+                if (_enAsset == null)
+                {
+                    _enAsset = AssetDatabase.LoadAssetAtPath<LocalizationAsset>(
+                        "Packages/net.kanameliser.editor-plus/Editor/Localization/en-us.po");
+                }
+                return _enAsset;
+            }
+        }
+
+        public static string S(string key)
+        {
+            if (EnAsset == null) return key;
+            var val = EnAsset.GetLocalizedString(key);
+            return string.IsNullOrEmpty(val) ? key : val;
+        }
+
+        public static void ShowLanguageUI() { }
+
+        public static void LocalizeUIElements(VisualElement root)
+        {
+            foreach (var element in root.Query(className: "ndmf-tr").Build())
+            {
+                var prop = element.GetType().GetProperty("label")
+                        ?? element.GetType().GetProperty("text");
+                if (prop == null) continue;
+
+                var key = prop.GetValue(element) as string;
+                if (string.IsNullOrEmpty(key)) continue;
+
+                prop.SetValue(element, S(key));
+
+                var tooltipKey = key + ":tooltip";
+                var tooltipVal = S(tooltipKey);
+                if (tooltipVal != tooltipKey)
+                    element.tooltip = tooltipVal;
+            }
+        }
+
+        public static void RegisterLanguageChangeCallback<T>(T owner, Action<T> callback)
+            where T : class
+        {
+        }
+#endif
+
+        public static string S(string key, params object[] args)
+        {
+            var template = S(key);
+            try { return string.Format(template, args); }
+            catch (FormatException) { return template; }
+        }
+    }
+}

--- a/Editor/Localization/Localization.cs.meta
+++ b/Editor/Localization/Localization.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f640dbe253c849cd934e04438e51b9a4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -1,0 +1,73 @@
+msgid ""
+msgstr ""
+"Language: en-us\n"
+
+# ── Common ──
+
+msgid "common.ok"
+msgstr "OK"
+
+msgid "common.cancel"
+msgstr "Cancel"
+
+msgid "common.delete"
+msgstr "Delete"
+
+# ── Component Manager ──
+
+msgid "componentManager.targetObject"
+msgstr "Target Object"
+
+msgid "componentManager.gameObjectFilter"
+msgstr "GameObject Filter:"
+
+msgid "componentManager.componentFilter"
+msgstr "Component Filter:"
+
+msgid "componentManager.includePathsInSearch"
+msgstr "Include paths in search"
+
+msgid "componentManager.showAllComponentsOnMatch"
+msgstr "Show all components of matching GameObjects"
+
+msgid "componentManager.showEmptyObjects"
+msgstr "Show GameObjects with no components"
+
+msgid "componentManager.selectPrompt"
+msgstr "Please select a GameObject to display components"
+
+msgid "componentManager.selectInHierarchy"
+msgstr "Select in Hierarchy"
+
+msgid "componentManager.removeSelectedItems"
+msgstr "Remove Selected Items"
+
+msgid "componentManager.confirmDeletion"
+msgstr "Confirm Deletion"
+
+msgid "componentManager.confirmDeletion.header"
+msgstr "Are you sure you want to delete the following items?"
+
+msgid "componentManager.confirmDeletion.selectedGameObjects"
+msgstr "[Selected GameObjects]"
+
+msgid "componentManager.confirmDeletion.selectedComponents"
+msgstr "[Selected Components]"
+
+#, csharp-format
+msgid "componentManager.confirmDeletion.moreGameObjects"
+msgstr "- ... (and {0} more GameObjects)"
+
+#, csharp-format
+msgid "componentManager.confirmDeletion.moreComponents"
+msgstr "- ... (and {0} more Components)"
+
+msgid "componentManager.confirmDeletion.undoAvailable"
+msgstr "Undo is available."
+
+msgid "componentManager.deletionPartiallyCompleted"
+msgstr "Deletion Partially Completed"
+
+#, csharp-format
+msgid "componentManager.deletionPartiallyCompleted.message"
+msgstr "Some selected items could not be deleted:\n\n{0}"

--- a/Editor/Localization/en-us.po.meta
+++ b/Editor/Localization/en-us.po.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 800d18963f6749b6906b87526c37a519
+LocalizationImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -1,0 +1,73 @@
+msgid ""
+msgstr ""
+"Language: ja-jp\n"
+
+# ── 共通 ──
+
+msgid "common.ok"
+msgstr "OK"
+
+msgid "common.cancel"
+msgstr "キャンセル"
+
+msgid "common.delete"
+msgstr "削除"
+
+# ── Component Manager ──
+
+msgid "componentManager.targetObject"
+msgstr "対象オブジェクト"
+
+msgid "componentManager.gameObjectFilter"
+msgstr "GameObjectフィルター:"
+
+msgid "componentManager.componentFilter"
+msgstr "Componentフィルター:"
+
+msgid "componentManager.includePathsInSearch"
+msgstr "パスを含めて検索"
+
+msgid "componentManager.showAllComponentsOnMatch"
+msgstr "一致したGameObjectの全Componentを表示"
+
+msgid "componentManager.showEmptyObjects"
+msgstr "Componentを持たないGameObjectも表示"
+
+msgid "componentManager.selectPrompt"
+msgstr "Componentを表示するGameObjectを選択してください"
+
+msgid "componentManager.selectInHierarchy"
+msgstr "Hierarchyで選択"
+
+msgid "componentManager.removeSelectedItems"
+msgstr "選択した項目を削除"
+
+msgid "componentManager.confirmDeletion"
+msgstr "削除の確認"
+
+msgid "componentManager.confirmDeletion.header"
+msgstr "以下の項目を削除しますか？"
+
+msgid "componentManager.confirmDeletion.selectedGameObjects"
+msgstr "【選択中のGameObject】"
+
+msgid "componentManager.confirmDeletion.selectedComponents"
+msgstr "【選択中のComponent】"
+
+#, csharp-format
+msgid "componentManager.confirmDeletion.moreGameObjects"
+msgstr "- ...（ほか {0} 件のGameObject）"
+
+#, csharp-format
+msgid "componentManager.confirmDeletion.moreComponents"
+msgstr "- ...（ほか {0} 件のComponent）"
+
+msgid "componentManager.confirmDeletion.undoAvailable"
+msgstr "Undoで元に戻せます。"
+
+msgid "componentManager.deletionPartiallyCompleted"
+msgstr "削除を完了できませんでした"
+
+#, csharp-format
+msgid "componentManager.deletionPartiallyCompleted.message"
+msgstr "以下の項目は削除できませんでした:\n\n{0}"

--- a/Editor/Localization/ja-jp.po.meta
+++ b/Editor/Localization/ja-jp.po.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9eae45501a674efdbb42a5788f6d28b5
+LocalizationImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## 概要

NDMFベースのローカライズ基盤を追加し、Component ManagerのUIを日英対応しました。

## 変更内容

### ローカライズ基盤
- NDMFの `Localizer` / `LanguageSwitcher` / `LanguagePrefs` をラップする `Editor/Localization/Localization.cs` を追加
  - NDMF 1.11.0+ がある場合: 言語切替つきのフルローカライズ(言語設定はNDMF系ツールと共有)
  - NDMFがない場合: Unityの `LocalizationAsset` による英語のみのフォールバックで動作
- GNU gettext形式の翻訳ファイル `en-us.po` / `ja-jp.po` を追加
- Editor用asmdefに `KEP_NDMF_LOCALIZATION` versionDefine(`nadena.dev.ndmf` `[1.11.0,2.0.0)`)を追加
  - 既存の `NDMF_INSTALLED`(バージョン制約なし)はそのまま維持

### Component Manager
- ハードコードされたUI文字列(ボタン、フィルターラベル、削除確認ダイアログ等)を `Localization.S()` に置き換え
- ウィンドウ上部に言語スイッチャーを追加し、`RegisterLanguageChangeCallback` で言語変更時に再描画
- 以下は意図的に英語のまま: ログメッセージ、Undoグループ名、「GameObject」「Component」列ヘッダー、フィルター判定に使われる `"Missing Component"`
- Component Manager系ファイルに残っていた日本語コメントをすべて英語に統一

## 補足

- メニュー項目(`[MenuItem]` のパス)は属性文字列がコンパイル時定数のためローカライズ不可
- 他のツール(MA Material Helper、AO Bounds Setter、Material Slot Remapping等)は後続PRで対応予定。Mesh Infoは英語のみのまま維持