### PR TITLE
feat: localize MA Material Helper dialogs via NDMF

### DIFF
--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -13,6 +13,71 @@ msgstr "Cancel"
 msgid "common.delete"
 msgstr "Delete"
 
+msgid "common.continue"
+msgstr "Continue"
+
+# ── MA Material Helper ──
+
+msgid "maMaterialHelper.dialogTitle"
+msgstr "MA Material Helper"
+
+msgid "maMaterialHelper.dialogTitle.error"
+msgstr "MA Material Helper - Error"
+
+msgid "maMaterialHelper.dialogTitle.warning"
+msgstr "MA Material Helper - Warning"
+
+msgid "maMaterialHelper.alreadyHasRemapping"
+msgstr "This object already has a Material Slot Remapping component."
+
+msgid "maMaterialHelper.noCopiedSetup"
+msgstr "No material setup has been copied. Please copy a material setup first."
+
+msgid "maMaterialHelper.noSetupGroups"
+msgstr "No material setup groups found"
+
+msgid "maMaterialHelper.noMatchingObjects"
+msgstr "No matching objects found between source and target"
+
+msgid "maMaterialHelper.invalidParameters"
+msgstr "Invalid parameters"
+
+msgid "maMaterialHelper.modularAvatarNotInstalled"
+msgstr "Modular Avatar is not installed"
+
+#, csharp-format
+msgid "maMaterialHelper.createSetterFailed"
+msgstr "Failed to create material setter: {0}"
+
+#, csharp-format
+msgid "maMaterialHelper.createSwapFailed"
+msgstr "Failed to create material swap: {0}"
+
+#, csharp-format
+msgid "maMaterialHelper.createSwapPerObjectFailed"
+msgstr "Failed to create material swap per object: {0}"
+
+#, csharp-format
+msgid "maMaterialHelper.operationFailed"
+msgstr "Failed to {0}:\n{1}"
+
+#, csharp-format
+msgid "maMaterialHelper.swapLimitation"
+msgstr ""
+"Material Swap Limitation Detected\n"
+"\n"
+"Material Swap cannot replace the same material in a mesh with multiple different materials.\n"
+"\n"
+"Detected conflicts:\n"
+"{0}\n"
+"\n"
+"Solution:\n"
+"Please use 'Create Material Setter' instead."
+
+#, csharp-format
+msgid "maMaterialHelper.swapLimitation.conflictHeader"
+msgstr "Material '{0}' has the following conflicts:"
+
 # ── Component Manager ──
 
 msgid "componentManager.targetObject"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -13,6 +13,71 @@ msgstr "キャンセル"
 msgid "common.delete"
 msgstr "削除"
 
+msgid "common.continue"
+msgstr "続行"
+
+# ── MA Material Helper ──
+
+msgid "maMaterialHelper.dialogTitle"
+msgstr "MA Material Helper"
+
+msgid "maMaterialHelper.dialogTitle.error"
+msgstr "MA Material Helper - エラー"
+
+msgid "maMaterialHelper.dialogTitle.warning"
+msgstr "MA Material Helper - 警告"
+
+msgid "maMaterialHelper.alreadyHasRemapping"
+msgstr "このオブジェクトには既にMaterial Slot Remappingコンポーネントが付いています。"
+
+msgid "maMaterialHelper.noCopiedSetup"
+msgstr "マテリアルセットアップがコピーされていません。先にCopy Material Setupを実行してください。"
+
+msgid "maMaterialHelper.noSetupGroups"
+msgstr "マテリアルセットアップのグループが見つかりませんでした"
+
+msgid "maMaterialHelper.noMatchingObjects"
+msgstr "コピー元とコピー先で一致するオブジェクトが見つかりませんでした"
+
+msgid "maMaterialHelper.invalidParameters"
+msgstr "パラメーターが不正です"
+
+msgid "maMaterialHelper.modularAvatarNotInstalled"
+msgstr "Modular Avatarがインストールされていません"
+
+#, csharp-format
+msgid "maMaterialHelper.createSetterFailed"
+msgstr "Material Setterの作成に失敗しました: {0}"
+
+#, csharp-format
+msgid "maMaterialHelper.createSwapFailed"
+msgstr "Material Swapの作成に失敗しました: {0}"
+
+#, csharp-format
+msgid "maMaterialHelper.createSwapPerObjectFailed"
+msgstr "Material Swap (Per Object) の作成に失敗しました: {0}"
+
+#, csharp-format
+msgid "maMaterialHelper.operationFailed"
+msgstr "処理に失敗しました ({0}):\n{1}"
+
+#, csharp-format
+msgid "maMaterialHelper.swapLimitation"
+msgstr ""
+"Material Swapの制限を検出しました\n"
+"\n"
+"Material Swapでは、同じメッシュ内の同じマテリアルを複数の異なるマテリアルに変更できません。\n"
+"\n"
+"検出された競合:\n"
+"{0}\n"
+"\n"
+"解決方法:\n"
+"代わりに「Create Material Setter」を使用してください。"
+
+#, csharp-format
+msgid "maMaterialHelper.swapLimitation.conflictHeader"
+msgstr "マテリアル '{0}' に以下の競合があります:"
+
 # ── Component Manager ──
 
 msgid "componentManager.targetObject"

--- a/Editor/MAMaterialHelper/Common/MAMaterialHelperUtils.cs
+++ b/Editor/MAMaterialHelper/Common/MAMaterialHelperUtils.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using UnityEditor;
 using UnityEngine;
+using Kanameliser.EditorPlus;
 
 namespace Kanameliser.Editor.MAMaterialHelper.Common
 {
@@ -41,7 +42,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
             result = new GenerationResult
             {
                 success = false,
-                message = "Modular Avatar is not installed"
+                message = Localization.S("maMaterialHelper.modularAvatarNotInstalled")
             };
             return false;
 #else
@@ -50,7 +51,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
                 result = new GenerationResult
                 {
                     success = false,
-                    message = "Invalid parameters"
+                    message = Localization.S("maMaterialHelper.invalidParameters")
                 };
                 return false;
             }
@@ -80,25 +81,35 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
         /// <summary>
         /// Shows an error dialog with consistent styling
         /// </summary>
-        public static void ShowErrorDialog(string message, string title = "MA Material Helper - Error")
+        public static void ShowErrorDialog(string message, string title = null)
         {
-            EditorUtility.DisplayDialog(title, message, "OK");
+            EditorUtility.DisplayDialog(
+                title ?? Localization.S("maMaterialHelper.dialogTitle.error"),
+                message,
+                Localization.S("common.ok"));
         }
 
         /// <summary>
-        /// Shows a warning dialog with OK/Cancel options
+        /// Shows a warning dialog with Continue/Cancel options
         /// </summary>
-        public static bool ShowWarningDialog(string message, string title = "MA Material Helper - Warning")
+        public static bool ShowWarningDialog(string message, string title = null)
         {
-            return EditorUtility.DisplayDialog(title, message, "Continue", "Cancel");
+            return EditorUtility.DisplayDialog(
+                title ?? Localization.S("maMaterialHelper.dialogTitle.warning"),
+                message,
+                Localization.S("common.continue"),
+                Localization.S("common.cancel"));
         }
 
         /// <summary>
         /// Shows an info dialog
         /// </summary>
-        public static void ShowInfoDialog(string message, string title = "MA Material Helper")
+        public static void ShowInfoDialog(string message, string title = null)
         {
-            EditorUtility.DisplayDialog(title, message, "OK");
+            EditorUtility.DisplayDialog(
+                title ?? Localization.S("maMaterialHelper.dialogTitle"),
+                message,
+                Localization.S("common.ok"));
         }
 
         /// <summary>
@@ -190,7 +201,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
             catch (System.Exception e)
             {
                 LogError($"Failed to {operationName}: {e.Message}");
-                ShowErrorDialog($"Failed to {operationName}:\n{e.Message}");
+                ShowErrorDialog(Localization.S("maMaterialHelper.operationFailed", operationName, e.Message));
                 return false;
             }
         }
@@ -207,7 +218,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.Common
             catch (System.Exception e)
             {
                 LogError($"Failed to {operationName}: {e.Message}");
-                ShowErrorDialog($"Failed to {operationName}:\n{e.Message}");
+                ShowErrorDialog(Localization.S("maMaterialHelper.operationFailed", operationName, e.Message));
                 return defaultValue;
             }
         }

--- a/Editor/MAMaterialHelper/MAMaterialHelperEditor.cs
+++ b/Editor/MAMaterialHelper/MAMaterialHelperEditor.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using Kanameliser.Editor.MAMaterialHelper.Common;
 using Kanameliser.Editor.MAMaterialHelper.MaterialSwap;
 using Kanameliser.Editor.MAMaterialHelper.MaterialSetter;
+using Kanameliser.EditorPlus;
 using Kanameliser.EditorPlus.Runtime;
 
 namespace Kanameliser.Editor.MAMaterialHelper
@@ -30,7 +31,7 @@ namespace Kanameliser.Editor.MAMaterialHelper
 
             if (selected.GetComponent<MaterialSlotRemapping>() != null)
             {
-                MAMaterialHelperUtils.ShowInfoDialog("This object already has a Material Slot Remapping component.");
+                MAMaterialHelperUtils.ShowInfoDialog(Localization.S("maMaterialHelper.alreadyHasRemapping"));
                 return;
             }
 
@@ -83,7 +84,7 @@ namespace Kanameliser.Editor.MAMaterialHelper
 
             if (!MAMaterialHelperSession.HasCopiedData)
             {
-                MAMaterialHelperUtils.ShowErrorDialog("No material setup has been copied. Please copy a material setup first.");
+                MAMaterialHelperUtils.ShowErrorDialog(Localization.S("maMaterialHelper.noCopiedSetup"));
                 return;
             }
 
@@ -110,7 +111,7 @@ namespace Kanameliser.Editor.MAMaterialHelper
 
             if (!MAMaterialHelperSession.HasCopiedData)
             {
-                MAMaterialHelperUtils.ShowErrorDialog("No material setup has been copied. Please copy a material setup first.");
+                MAMaterialHelperUtils.ShowErrorDialog(Localization.S("maMaterialHelper.noCopiedSetup"));
                 return;
             }
 
@@ -137,7 +138,7 @@ namespace Kanameliser.Editor.MAMaterialHelper
 
             if (!MAMaterialHelperSession.HasCopiedData)
             {
-                MAMaterialHelperUtils.ShowErrorDialog("No material setup has been copied. Please copy a material setup first.");
+                MAMaterialHelperUtils.ShowErrorDialog(Localization.S("maMaterialHelper.noCopiedSetup"));
                 return;
             }
 
@@ -168,7 +169,7 @@ namespace Kanameliser.Editor.MAMaterialHelper
 
             if (!MAMaterialHelperSession.HasCopiedData)
             {
-                MAMaterialHelperUtils.ShowErrorDialog("No material setup has been copied. Please copy a material setup first.");
+                MAMaterialHelperUtils.ShowErrorDialog(Localization.S("maMaterialHelper.noCopiedSetup"));
                 return;
             }
 

--- a/Editor/MAMaterialHelper/MaterialSetter/MaterialSetterGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSetter/MaterialSetterGenerator.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using Kanameliser.Editor.MAMaterialHelper.Common;
+using Kanameliser.EditorPlus;
 #if MODULAR_AVATAR_INSTALLED
 using nadena.dev.modular_avatar.core;
 #endif
@@ -40,7 +41,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSetter
                     return new GenerationResult
                     {
                         success = false,
-                        message = "No material setup groups found"
+                        message = Localization.S("maMaterialHelper.noSetupGroups")
                     };
                 }
 
@@ -87,7 +88,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSetter
                     return new GenerationResult
                     {
                         success = false,
-                        message = "No matching objects found between source and target"
+                        message = Localization.S("maMaterialHelper.noMatchingObjects")
                     };
                 }
 
@@ -112,7 +113,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSetter
                 return new GenerationResult
                 {
                     success = false,
-                    message = $"Failed to create material setter: {e.Message}"
+                    message = Localization.S("maMaterialHelper.createSetterFailed", e.Message)
                 };
             }
         }

--- a/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
+++ b/Editor/MAMaterialHelper/MaterialSwap/MaterialSwapGenerator.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using Kanameliser.Editor.MAMaterialHelper.Common;
+using Kanameliser.EditorPlus;
 #if MODULAR_AVATAR_INSTALLED
 using nadena.dev.modular_avatar.core;
 #endif
@@ -46,7 +47,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                 return new GenerationResult
                 {
                     success = false,
-                    message = $"Failed to create material swap: {e.Message}"
+                    message = Localization.S("maMaterialHelper.createSwapFailed", e.Message)
                 };
             }
         }
@@ -75,7 +76,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                 return new GenerationResult
                 {
                     success = false,
-                    message = $"Failed to create material swap per object: {e.Message}"
+                    message = Localization.S("maMaterialHelper.createSwapPerObjectFailed", e.Message)
                 };
             }
         }
@@ -196,7 +197,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                 return new GenerationResult
                 {
                     success = false,
-                    message = "No material setup groups found"
+                    message = Localization.S("maMaterialHelper.noSetupGroups")
                 };
             }
 
@@ -248,7 +249,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
                 return new GenerationResult
                 {
                     success = false,
-                    message = "No matching objects found between source and target"
+                    message = Localization.S("maMaterialHelper.noMatchingObjects")
                 };
             }
 
@@ -297,16 +298,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
         /// </summary>
         private static string BuildLimitationErrorMessage(List<string> conflictDetails)
         {
-            var errorMessage = "Material Swap Limitation Detected\n\n" +
-                               "Material Swapでは、同じメッシュ内の同じマテリアルを複数の異なるマテリアルに変更できません。\n" +
-                               "Material Swap cannot replace the same material in a mesh with multiple different materials.\n\n" +
-                               "Detected conflicts / 検出された競合:\n" +
-                               string.Join("\n", conflictDetails) +
-                               "\n\n" +
-                               "解決方法 / Solution:\n" +
-                               "代わりに「Create Material Setter」を使用してください。\n" +
-                               "Please use 'Create Material Setter' instead.";
-            return errorMessage;
+            return Localization.S("maMaterialHelper.swapLimitation", string.Join("\n", conflictDetails));
         }
 
         /// <summary>
@@ -391,7 +383,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.MaterialSwap
 
                 if (swapInfo.HasSameObjectMultipleTargets(out var conflictDetails))
                 {
-                    limitationErrors.Add($"\nMaterial '{fromMaterial.name}' has the following conflicts:");
+                    limitationErrors.Add("\n" + Localization.S("maMaterialHelper.swapLimitation.conflictHeader", fromMaterial.name));
                     limitationErrors.AddRange(conflictDetails);
                 }
             }

--- a/Editor/Tests/MatchingRegressionTests.cs
+++ b/Editor/Tests/MatchingRegressionTests.cs
@@ -602,17 +602,13 @@ namespace Kanameliser.EditorPlus.Tests
             return renderer;
         }
 
+        // Mirrors ProcessMaterialSwapGroups + BuildLimitationErrorMessage message assembly
         private static string LimitationMessage(Material from, string objectName, string slotDetails)
         {
-            return "Material Swap Limitation Detected\n\n" +
-                   "Material Swapでは、同じメッシュ内の同じマテリアルを複数の異なるマテリアルに変更できません。\n" +
-                   "Material Swap cannot replace the same material in a mesh with multiple different materials.\n\n" +
-                   "Detected conflicts / 検出された競合:\n\n" +
-                   $"Material '{from.name}' has the following conflicts:\n" +
-                   $"  - '{objectName}': {slotDetails}\n\n" +
-                   "解決方法 / Solution:\n" +
-                   "代わりに「Create Material Setter」を使用してください。\n" +
-                   "Please use 'Create Material Setter' instead.";
+            var conflictDetails =
+                "\n" + Localization.S("maMaterialHelper.swapLimitation.conflictHeader", from.name) +
+                "\n" + $"  - '{objectName}': {slotDetails}";
+            return Localization.S("maMaterialHelper.swapLimitation", conflictDetails);
         }
 #else
         [Test, Ignore("Material Swap generation requires Modular Avatar.")]


### PR DESCRIPTION
## 概要

MA Material Helperのダイアログメッセージを日英対応しました(#44 の続き)。

## 変更内容

- メニューコマンドのエラー/情報ダイアログを `Localization.S()` に置き換え
- ダイアログ共通部品(`MAMaterialHelperUtils`)のタイトル・ボタン(OK / Continue / Cancel)・例外ダイアログをローカライズ
- ジェネレーターの失敗メッセージ(ダイアログ表示されるもの)をローカライズ
- 日英併記だったMaterial Swap制限メッセージを、言語設定に応じた単一言語表示に整理
- テストの期待値を `Localization.S()` 経由の組み立てに変更(言語設定に依存せずパス)
- 以下は意図的に英語のまま: コンソールログ、成功時ログメッセージ

## 対象外

- Material Copier / Toggle Objects Active: ユーザー向けUI文字列がない(ログのみ)ため対象外