### PR TITLE
feat: localize AO Bounds Setter and Material Slot Remapping inspector

### DIFF
--- a/Editor/AOBoundsSetter/AOBoundsSetterWindow.cs
+++ b/Editor/AOBoundsSetter/AOBoundsSetterWindow.cs
@@ -50,11 +50,30 @@ namespace Kanameliser.EditorPlus
             mainContainer.AddToClassList("main-container");
             root.Add(mainContainer);
 
+            // Language switcher at top
+            var langSwitcher = new IMGUIContainer(Localization.ShowLanguageUI);
+            langSwitcher.AddToClassList("language-switcher");
+            mainContainer.Add(langSwitcher);
+
             CreateRootObjectSection(mainContainer);
             CreateBatchSettingsSection(mainContainer);
             CreateMeshListSection(mainContainer);
 
             UpdateApplyButtonState();
+
+            // Localize ndmf-tr elements (kept up to date on language change by NDMF)
+            Localization.LocalizeUIElements(root);
+
+            // Tooltips set outside ndmf-tr need a manual refresh on language change
+            Localization.RegisterLanguageChangeCallback(this, w => w.UpdateLocalizedTooltips());
+        }
+
+        private void UpdateLocalizedTooltips()
+        {
+            if (refreshButton != null)
+            {
+                refreshButton.tooltip = Localization.S("aoBounds.refresh:tooltip");
+            }
         }
 
         private void CreateRootObjectSection(VisualElement container)
@@ -62,8 +81,9 @@ namespace Kanameliser.EditorPlus
             var section = new VisualElement();
             section.AddToClassList("root-object-section");
 
-            var label = new Label("Root Object");
+            var label = new Label("aoBounds.rootObject");
             label.AddToClassList("section-label");
+            label.AddToClassList("ndmf-tr");
             section.Add(label);
 
             // Root Object Field with Refresh Button
@@ -73,7 +93,7 @@ namespace Kanameliser.EditorPlus
             refreshButton = new Button(OnRefreshButtonClicked)
             {
                 text = "↻",
-                tooltip = "Reload meshes from the root object"
+                tooltip = Localization.S("aoBounds.refresh:tooltip")
             };
             refreshButton.AddToClassList("refresh-button");
             rootObjectContainer.Add(refreshButton);
@@ -102,12 +122,14 @@ namespace Kanameliser.EditorPlus
             var section = new VisualElement();
             section.AddToClassList("section-container");
 
-            var label = new Label("Batch Settings");
+            var label = new Label("aoBounds.batchSettings");
             label.AddToClassList("section-title");
+            label.AddToClassList("ndmf-tr");
             section.Add(label);
 
-            var aoLabel = new Label("Anchor Override:");
+            var aoLabel = new Label("aoBounds.anchorOverride");
             aoLabel.AddToClassList("field-label");
+            aoLabel.AddToClassList("ndmf-tr");
             section.Add(aoLabel);
 
             var anchorOverrideContainer = new VisualElement();
@@ -130,8 +152,9 @@ namespace Kanameliser.EditorPlus
 
             section.Add(anchorOverrideContainer);
 
-            var rootBoneLabel = new Label("Root Bone (SkinnedMeshRenderer only):");
+            var rootBoneLabel = new Label("aoBounds.rootBone");
             rootBoneLabel.AddToClassList("field-label-with-spacing");
+            rootBoneLabel.AddToClassList("ndmf-tr");
             section.Add(rootBoneLabel);
 
             var rootBoneContainer = new VisualElement();
@@ -154,8 +177,9 @@ namespace Kanameliser.EditorPlus
 
             section.Add(rootBoneContainer);
 
-            var boundsLabel = new Label("Bounds (SkinnedMeshRenderer only):");
+            var boundsLabel = new Label("aoBounds.bounds");
             boundsLabel.AddToClassList("field-label-with-spacing");
+            boundsLabel.AddToClassList("ndmf-tr");
             section.Add(boundsLabel);
 
             boundsCenterField = new Vector3Field("Center");
@@ -169,9 +193,10 @@ namespace Kanameliser.EditorPlus
 
             applyButton = new Button(OnApplyButtonClicked)
             {
-                text = "Apply to Selected Meshes"
+                text = "aoBounds.apply"
             };
             applyButton.AddToClassList("apply-button");
+            applyButton.AddToClassList("ndmf-tr");
             section.Add(applyButton);
 
             container.Add(section);
@@ -182,8 +207,9 @@ namespace Kanameliser.EditorPlus
             var section = new VisualElement();
             section.AddToClassList("mesh-list-section");
 
-            var label = new Label("Mesh List");
+            var label = new Label("aoBounds.meshList");
             label.AddToClassList("section-label");
+            label.AddToClassList("ndmf-tr");
             section.Add(label);
 
             // Container for header and list
@@ -215,20 +241,24 @@ namespace Kanameliser.EditorPlus
             headerToggle.RegisterValueChangedCallback(OnHeaderToggleChanged);
             header.Add(headerToggle);
 
-            var objectNameLabel = new Label("Object Name");
+            var objectNameLabel = new Label("aoBounds.header.objectName");
             objectNameLabel.AddToClassList("header-label-object-name");
+            objectNameLabel.AddToClassList("ndmf-tr");
             header.Add(objectNameLabel);
 
-            var aoLabel = new Label("Anchor Override");
+            var aoLabel = new Label("aoBounds.header.anchorOverride");
             aoLabel.AddToClassList("header-label-ao");
+            aoLabel.AddToClassList("ndmf-tr");
             header.Add(aoLabel);
 
-            var rootBoneLabel = new Label("Root Bone");
+            var rootBoneLabel = new Label("aoBounds.header.rootBone");
             rootBoneLabel.AddToClassList("header-label-root-bone");
+            rootBoneLabel.AddToClassList("ndmf-tr");
             header.Add(rootBoneLabel);
 
-            var boundsLabel = new Label("Bounds");
+            var boundsLabel = new Label("aoBounds.header.bounds");
             boundsLabel.AddToClassList("header-label-bounds");
+            boundsLabel.AddToClassList("ndmf-tr");
             header.Add(boundsLabel);
 
             return header;

--- a/Editor/AOBoundsSetter/AOBoundsSetterWindow.uss
+++ b/Editor/AOBoundsSetter/AOBoundsSetterWindow.uss
@@ -1,5 +1,10 @@
 /* AO Bounds Setter Window Styles */
 
+/* Language switcher */
+.language-switcher {
+    margin-bottom: 8px;
+}
+
 /* Main container */
 .main-container {
     padding: 10px;

--- a/Editor/AOBoundsSetter/TransformSelectorWindow.cs
+++ b/Editor/AOBoundsSetter/TransformSelectorWindow.cs
@@ -77,7 +77,7 @@ namespace Kanameliser.EditorPlus
             searchField.RegisterValueChangedCallback(OnSearchTextChanged);
 
             // Add placeholder text
-            var placeholderLabel = new Label("Search...");
+            var placeholderLabel = new Label(Localization.S("aoBounds.search"));
             placeholderLabel.style.position = Position.Absolute;
             placeholderLabel.style.left = 3;
             placeholderLabel.style.top = 2;

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -123,9 +123,11 @@ msgstr "Search..."
 
 msgid "slotRemap.description"
 msgstr ""
-"Maps this (converted) outfit's material slots back to a reference (original) outfit, "
+"Use this when color setups created with Create Material Setter etc. do not map correctly "
+"after converting an outfit with fitting tools such as Mochifitter.\n"
+"Maps the converted outfit's material slots back to a reference (original) outfit, "
 "so Material Setter/Swap color setups land on the correct slots.\n"
-"Generate the mapping right after conversion, before recoloring the outfit."
+"Generate the mapping right after conversion, before recoloring (changing mesh materials) the outfit."
 
 msgid "slotRemap.referencePrefab"
 msgstr "Reference Prefab"

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -78,6 +78,98 @@ msgstr ""
 msgid "maMaterialHelper.swapLimitation.conflictHeader"
 msgstr "Material '{0}' has the following conflicts:"
 
+# ── AO Bounds Setter ──
+
+msgid "aoBounds.rootObject"
+msgstr "Root Object"
+
+msgid "aoBounds.refresh:tooltip"
+msgstr "Reload meshes from the root object"
+
+msgid "aoBounds.batchSettings"
+msgstr "Batch Settings"
+
+msgid "aoBounds.anchorOverride"
+msgstr "Anchor Override:"
+
+msgid "aoBounds.rootBone"
+msgstr "Root Bone (SkinnedMeshRenderer only):"
+
+msgid "aoBounds.bounds"
+msgstr "Bounds (SkinnedMeshRenderer only):"
+
+msgid "aoBounds.apply"
+msgstr "Apply to Selected Meshes"
+
+msgid "aoBounds.meshList"
+msgstr "Mesh List"
+
+msgid "aoBounds.header.objectName"
+msgstr "Object Name"
+
+msgid "aoBounds.header.anchorOverride"
+msgstr "Anchor Override"
+
+msgid "aoBounds.header.rootBone"
+msgstr "Root Bone"
+
+msgid "aoBounds.header.bounds"
+msgstr "Bounds"
+
+msgid "aoBounds.search"
+msgstr "Search..."
+
+# ── Material Slot Remapping ──
+
+msgid "slotRemap.description"
+msgstr ""
+"Maps this (converted) outfit's material slots back to a reference (original) outfit, "
+"so Material Setter/Swap color setups land on the correct slots.\n"
+"Generate the mapping right after conversion, before recoloring the outfit."
+
+msgid "slotRemap.referencePrefab"
+msgstr "Reference Prefab"
+
+msgid "slotRemap.generateMapping"
+msgstr "Generate Mapping"
+
+msgid "slotRemap.ambiguousDialog.title"
+msgstr "Ambiguous Material Slot Mapping"
+
+msgid "slotRemap.ambiguousDialog.useEstimated"
+msgstr "Use Estimated Mapping"
+
+#, csharp-format
+msgid "slotRemap.ambiguousDialog.message"
+msgstr ""
+"Some material or empty slots occur more than once, so their submesh "
+"correspondence could not be determined reliably.\n"
+"\n"
+"{0}\n"
+"\n"
+"If you continue, the estimated mapping will be stored. Review and adjust these "
+"slots manually before creating Material Setter/Swap components.\n"
+"\n"
+"Use the estimated mapping?"
+
+#, csharp-format
+msgid "slotRemap.ambiguousDialog.more"
+msgstr "...and {0} more. All details will be shown in the Inspector warnings."
+
+#, csharp-format
+msgid "slotRemap.mappingGenerated"
+msgstr "Mapping generated for {0} renderer(s)."
+
+msgid "slotRemap.noMapping"
+msgstr "No mapping generated yet."
+
+#, csharp-format
+msgid "slotRemap.slotMappings"
+msgstr "Slot Mappings ({0} renderers)"
+
+msgid "slotRemap.resetToIdentity"
+msgstr "Reset This Renderer To Identity"
+
 # ── Component Manager ──
 
 msgid "componentManager.targetObject"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -78,6 +78,98 @@ msgstr ""
 msgid "maMaterialHelper.swapLimitation.conflictHeader"
 msgstr "マテリアル '{0}' に以下の競合があります:"
 
+# ── AO Bounds Setter ──
+
+msgid "aoBounds.rootObject"
+msgstr "Rootオブジェクト"
+
+msgid "aoBounds.refresh:tooltip"
+msgstr "Rootオブジェクトからメッシュを再読み込み"
+
+msgid "aoBounds.batchSettings"
+msgstr "一括設定"
+
+msgid "aoBounds.anchorOverride"
+msgstr "Anchor Override:"
+
+msgid "aoBounds.rootBone"
+msgstr "Root Bone（SkinnedMeshRendererのみ）:"
+
+msgid "aoBounds.bounds"
+msgstr "Bounds（SkinnedMeshRendererのみ）:"
+
+msgid "aoBounds.apply"
+msgstr "選択したメッシュに適用"
+
+msgid "aoBounds.meshList"
+msgstr "メッシュ一覧"
+
+msgid "aoBounds.header.objectName"
+msgstr "オブジェクト名"
+
+msgid "aoBounds.header.anchorOverride"
+msgstr "Anchor Override"
+
+msgid "aoBounds.header.rootBone"
+msgstr "Root Bone"
+
+msgid "aoBounds.header.bounds"
+msgstr "Bounds"
+
+msgid "aoBounds.search"
+msgstr "検索..."
+
+# ── Material Slot Remapping ──
+
+msgid "slotRemap.description"
+msgstr ""
+"この（変換後の）衣装のマテリアルスロットを参照元（変換前）の衣装に対応付け、"
+"Material Setter/Swapの色設定が正しいスロットに適用されるようにします。\n"
+"マッピングは変換直後、色替えを作成する前に生成してください。"
+
+msgid "slotRemap.referencePrefab"
+msgstr "参照元Prefab"
+
+msgid "slotRemap.generateMapping"
+msgstr "マッピングを生成"
+
+msgid "slotRemap.ambiguousDialog.title"
+msgstr "マテリアルスロットの対応が曖昧です"
+
+msgid "slotRemap.ambiguousDialog.useEstimated"
+msgstr "推定マッピングを使用"
+
+#, csharp-format
+msgid "slotRemap.ambiguousDialog.message"
+msgstr ""
+"同じマテリアルまたは空のスロットが複数あるため、サブメッシュの対応関係を"
+"確実に決定できませんでした。\n"
+"\n"
+"{0}\n"
+"\n"
+"続行すると推定マッピングが保存されます。Material Setter/Swapを作成する前に、"
+"該当スロットを手動で確認・調整してください。\n"
+"\n"
+"推定マッピングを使用しますか？"
+
+#, csharp-format
+msgid "slotRemap.ambiguousDialog.more"
+msgstr "...ほか {0} 件。詳細はInspectorの警告に表示されます。"
+
+#, csharp-format
+msgid "slotRemap.mappingGenerated"
+msgstr "{0} 件のRendererのマッピングを生成しました。"
+
+msgid "slotRemap.noMapping"
+msgstr "マッピングはまだ生成されていません。"
+
+#, csharp-format
+msgid "slotRemap.slotMappings"
+msgstr "スロットマッピング（{0} 件のRenderer）"
+
+msgid "slotRemap.resetToIdentity"
+msgstr "このRendererをそのままの対応にリセット"
+
 # ── Component Manager ──
 
 msgid "componentManager.targetObject"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -81,10 +81,10 @@ msgstr "マテリアル '{0}' に以下の競合があります:"
 # ── AO Bounds Setter ──
 
 msgid "aoBounds.rootObject"
-msgstr "Rootオブジェクト"
+msgstr "ルートオブジェクト"
 
 msgid "aoBounds.refresh:tooltip"
-msgstr "Rootオブジェクトからメッシュを再読み込み"
+msgstr "ルートオブジェクトからメッシュを再読み込み"
 
 msgid "aoBounds.batchSettings"
 msgstr "一括設定"
@@ -123,9 +123,10 @@ msgstr "検索..."
 
 msgid "slotRemap.description"
 msgstr ""
-"この（変換後の）衣装のマテリアルスロットを参照元（変換前）の衣装に対応付け、"
+"もちふぃった～等を利用し変換した際、Create Material Setterなどでの色変更がうまくマッピングされないときに利用してください。\n"
+"変換後の衣装のマテリアルスロットを参照元（変換前）の衣装に対応付け、"
 "Material Setter/Swapの色設定が正しいスロットに適用されるようにします。\n"
-"マッピングは変換直後、色替えを作成する前に生成してください。"
+"マッピングは変換直後、色改変（メッシュのマテリアル変更）を実施する前に生成してください。"
 
 msgid "slotRemap.referencePrefab"
 msgstr "参照元Prefab"
@@ -142,7 +143,7 @@ msgstr "推定マッピングを使用"
 #, csharp-format
 msgid "slotRemap.ambiguousDialog.message"
 msgstr ""
-"同じマテリアルまたは空のスロットが複数あるため、サブメッシュの対応関係を"
+"同じメッシュに同じマテリアルまたは空のスロットが複数あるため、サブメッシュの対応関係を"
 "確実に決定できませんでした。\n"
 "\n"
 "{0}\n"

--- a/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
+++ b/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
 using Kanameliser.Editor.MAMaterialHelper.Common;
+using Kanameliser.EditorPlus;
 using Kanameliser.EditorPlus.Runtime;
 
 namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
@@ -18,17 +19,13 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
         {
             var component = (MaterialSlotRemapping)target;
 
-            EditorGUILayout.HelpBox(
-                "Maps this (converted) outfit's material slots back to a reference (original) outfit, " +
-                "so Material Setter/Swap color setups land on the correct slots.\n" +
-                "Generate the mapping right after conversion, before recoloring the outfit.",
-                MessageType.Info);
+            EditorGUILayout.HelpBox(Localization.S("slotRemap.description"), MessageType.Info);
 
             EditorGUILayout.Space();
 
             EditorGUI.BeginChangeCheck();
             var newRef = (GameObject)EditorGUILayout.ObjectField(
-                "Reference Prefab", component.referencePrefab, typeof(GameObject), true);
+                Localization.S("slotRemap.referencePrefab"), component.referencePrefab, typeof(GameObject), true);
             if (EditorGUI.EndChangeCheck())
             {
                 Undo.RecordObject(component, "Set Reference Prefab");
@@ -38,7 +35,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
 
             using (new EditorGUI.DisabledScope(component.referencePrefab == null))
             {
-                if (GUILayout.Button("Generate Mapping"))
+                if (GUILayout.Button(Localization.S("slotRemap.generateMapping")))
                 {
                     GenerateMapping(component);
                 }
@@ -58,10 +55,10 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
             {
                 if (result.hasAmbiguousMappings &&
                     !EditorUtility.DisplayDialog(
-                        "Ambiguous Material Slot Mapping",
+                        Localization.S("slotRemap.ambiguousDialog.title"),
                         BuildAmbiguityConfirmationMessage(result),
-                        "Use Estimated Mapping",
-                        "Cancel"))
+                        Localization.S("slotRemap.ambiguousDialog.useEstimated"),
+                        Localization.S("common.cancel")))
                 {
                     _lastResult = null;
                     return;
@@ -87,17 +84,11 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
             string details = string.Join("\n\n", displayedDetails);
             if (result.ambiguousMappingDetails.Count > displayedCount)
             {
-                details += $"\n\n...and {result.ambiguousMappingDetails.Count - displayedCount} more. " +
-                           "All details will be shown in the Inspector warnings.";
+                details += "\n\n" + Localization.S("slotRemap.ambiguousDialog.more",
+                    result.ambiguousMappingDetails.Count - displayedCount);
             }
 
-            return
-                "Some material or empty slots occur more than once, so their submesh " +
-                "correspondence could not be determined reliably.\n\n" +
-                details + "\n\n" +
-                "If you continue, the estimated mapping will be stored. Review and adjust these " +
-                "slots manually before creating Material Setter/Swap components.\n\n" +
-                "Use the estimated mapping?";
+            return Localization.S("slotRemap.ambiguousDialog.message", details);
         }
 
         private void DrawResultMessages()
@@ -110,18 +101,18 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
                 EditorGUILayout.HelpBox(warning, MessageType.Warning);
 
             if (_lastResult.success && _lastResult.warnings.Count == 0 && _lastResult.errors.Count == 0)
-                EditorGUILayout.HelpBox($"Mapping generated for {_lastResult.matchedRendererCount} renderer(s).", MessageType.Info);
+                EditorGUILayout.HelpBox(Localization.S("slotRemap.mappingGenerated", _lastResult.matchedRendererCount), MessageType.Info);
         }
 
         private void DrawRemaps(MaterialSlotRemapping component)
         {
             if (component.remaps == null || component.remaps.Count == 0)
             {
-                EditorGUILayout.LabelField("No mapping generated yet.", EditorStyles.miniLabel);
+                EditorGUILayout.LabelField(Localization.S("slotRemap.noMapping"), EditorStyles.miniLabel);
                 return;
             }
 
-            EditorGUILayout.LabelField($"Slot Mappings ({component.remaps.Count} renderers)", EditorStyles.boldLabel);
+            EditorGUILayout.LabelField(Localization.S("slotRemap.slotMappings", component.remaps.Count), EditorStyles.boldLabel);
 
             foreach (var remap in component.remaps)
             {
@@ -136,7 +127,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
 
                 EditorGUI.indentLevel++;
                 DrawRemapEntry(component, remap);
-                if (GUILayout.Button("Reset This Renderer To Identity", GUILayout.Width(260)))
+                if (GUILayout.Button(Localization.S("slotRemap.resetToIdentity"), GUILayout.Width(260)))
                 {
                     ResetToIdentity(component, remap);
                 }


### PR DESCRIPTION
## 概要

AO Bounds SetterとMaterial Slot Remapping InspectorのUIを日英対応しました(#44, #45 の続き)。これで主要ツールのローカライズは完了(Mesh Infoは対象外)。

## 変更内容

### AO Bounds Setter(UI Toolkit)
- ラベル・ボタン・リストヘッダーをNDMFの `ndmf-tr` クラス + `LocalizeUIElements` 方式でローカライズ(言語切替時に自動再適用)
- ウィンドウ上部に言語スイッチャーを追加
- リフレッシュボタンのtooltipは言語変更コールバックで手動更新
- Transform選択ポップアップの検索プレースホルダーもローカライズ

### Material Slot Remapping Inspector(IMGUI)
- 説明・フィールドラベル・ボタン・生成結果メッセージを `Localization.S()` に置き換え
- 曖昧マッピング確認ダイアログ(タイトル・本文・ボタン)をローカライズ
- ジェネレーターの警告/エラー詳細(スロット番号等の診断情報)は意図的に英語のまま(テストで文字列をアサートしているため)