### PR TITLE
feat: rework MA Material Helper context menu and add guide window 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Japanese language support (NDMF localization)** — Component Manager, MA Material Helper dialogs, AO Bounds Setter, and the Material Slot Remapping Inspector are now available in Japanese. The language follows NDMF's shared language preference and can be switched from the language selector shown in each window (requires NDMF 1.11.0+). Without NDMF, the UI remains in English.
 - **MA Material Helper: Material Slot Remapping** — Added a `Kanameliser Editor Plus > Add Material Slot Remapping` component (Hierarchy right-click). Use it when an outfit conversion (e.g. auto-fitting tools) reorders a renderer's material slots and Material Setter/Swap color changes no longer land correctly. It maps the converted outfit's material slots back to the original (reference) outfit's slots, so Material Setter/Swap color changes apply to the correct slots even when the conversion shifted the slot order.
 - **MA Material Helper / Material Copier: Verbose Matching Logs toggle** — Added a menu toggle at `Tools > Kanameliser Editor Plus > [Settings] > Verbose Matching Logs` to enable detailed matching diagnostics in the console.
+- **MA Material Helper: `[How to Create Color Menu]` guide window** — Added a guide item to the Hierarchy right-click menu. It opens a window explaining the two-step workflow, with a live status and a list of the currently copied objects (available in English and Japanese).
+
+### Changed
+
+- **MA Material Helper: Clearer Hierarchy context menu naming** — Renamed `Copy Material Setup` to `Copy Color Variants` and `Create Material Setter` to `Create Color Menu`, so the commands describe the color-menu workflow instead of internal component names and are no longer confusable with `Copy Materials`. The `[Optional]` variants and Material Swap commands moved into an `Advanced` submenu.
 
 ### Removed
 
@@ -45,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **日本語UI対応（NDMFローカライズ）** — Component Manager、MA Material Helperのダイアログ、AO Bounds Setter、Material Slot RemappingのInspectorが日本語表示に対応しました。言語はNDMF共通の言語設定に従い、各ウィンドウの言語セレクターから切り替えできます（NDMF 1.11.0以上が必要）。NDMFがない環境では従来どおり英語表示になります。
 - **MA Material Helper: Material Slot Remapping** — `Kanameliser Editor Plus > Add Material Slot Remapping`（ヒエラルキー右クリック）コンポーネントを追加。もちふぃった～等で変換を行った際にマテリアルスロット順が変わってしまい、Material Setter/Swapの色変更がうまく行かないときに使用します。変換後の衣装のマテリアルスロットを元（参照）衣装のスロットに対応付けることで、変換でスロット順がずれていてもMaterial Setter/Swapの色変更が正しいスロットに適用されるようにします。
 - **MA Material Helper / Material Copier: 詳細マッチングログのトグル** — `Tools > Kanameliser Editor Plus > [Settings] > Verbose Matching Logs` にデバッグ用ログのトグルを追加。有効にするとマッチング判定の詳細情報をコンソールに出力します。
+- **MA Material Helper: `[How to Create Color Menu]` ガイドウィンドウ** — ヒエラルキー右クリックメニューにガイド項目を追加。2ステップの作成手順の説明と、コピー済みオブジェクトの状態・一覧をリアルタイム表示するウィンドウが開きます（日本語・英語対応）。
+
+### 変更
+
+- **MA Material Helper: 右クリックメニュー名の見直し** — `Copy Material Setup` を `Copy Color Variants` に、`Create Material Setter` を `Create Color Menu` に名称変更しました。コマンド名が内部コンポーネント名ではなく「色変更メニューを作る」という目的を表すようになり、`Copy Materials` とも混同しにくくなりました。あわせて `[Optional]` 系とMaterial Swap系のコマンドは `Advanced` サブメニューに移動しました。
 
 ### 削除
 

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -31,7 +31,23 @@ msgid "maMaterialHelper.alreadyHasRemapping"
 msgstr "This object already has a Material Slot Remapping component."
 
 msgid "maMaterialHelper.noCopiedSetup"
-msgstr "No material setup has been copied. Please copy a material setup first."
+msgstr "No color variants have been copied yet.\nSelect the color variant prefab(s) and run 'Copy Color Variants' first."
+
+msgid "maMaterialHelper.guide.title"
+msgstr "How to Create Color Menu"
+
+msgid "maMaterialHelper.guide.step1"
+msgstr "Select the color variant prefab(s) and right-click → 'Copy Color Variants' (multiple selection supported)"
+
+msgid "maMaterialHelper.guide.step2"
+msgstr "Select the target outfit and right-click → 'Create Color Menu' (this item appears after Step 1)"
+
+msgid "maMaterialHelper.guide.statusNotCopied"
+msgstr "No color variants copied yet — start with Step 1"
+
+#, csharp-format
+msgid "maMaterialHelper.guide.statusCopied"
+msgstr "Copied from '{0}' ({1} objects, {2} materials).\nNow select the outfit and run Step 2."
 
 msgid "maMaterialHelper.noSetupGroups"
 msgstr "No material setup groups found"
@@ -72,7 +88,7 @@ msgstr ""
 "{0}\n"
 "\n"
 "Solution:\n"
-"Please use 'Create Material Setter' instead."
+"Please use 'Create Color Menu' instead."
 
 #, csharp-format
 msgid "maMaterialHelper.swapLimitation.conflictHeader"
@@ -123,7 +139,7 @@ msgstr "Search..."
 
 msgid "slotRemap.description"
 msgstr ""
-"Use this when color setups created with Create Material Setter etc. do not map correctly "
+"Use this when color setups created with Create Color Menu etc. do not map correctly "
 "after converting an outfit with fitting tools such as Mochifitter.\n"
 "Maps the converted outfit's material slots back to a reference (original) outfit, "
 "so Material Setter/Swap color setups land on the correct slots.\n"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -31,7 +31,23 @@ msgid "maMaterialHelper.alreadyHasRemapping"
 msgstr "このオブジェクトには既にMaterial Slot Remappingコンポーネントが付いています。"
 
 msgid "maMaterialHelper.noCopiedSetup"
-msgstr "マテリアルセットアップがコピーされていません。先にCopy Material Setupを実行してください。"
+msgstr "色データがまだコピーされていません。\n先に色違いのPrefabを選択して「Copy Color Variants」を実行してください。"
+
+msgid "maMaterialHelper.guide.title"
+msgstr "色変更メニューの作り方"
+
+msgid "maMaterialHelper.guide.step1"
+msgstr "色違いのPrefabを選択して右クリック →「Copy Color Variants」（複数選択可）"
+
+msgid "maMaterialHelper.guide.step2"
+msgstr "衣装本体を選択して右クリック →「Create Color Menu」（手順1の後にメニューへ表示されます）"
+
+msgid "maMaterialHelper.guide.statusNotCopied"
+msgstr "まだ色データがコピーされていません。手順1から始めてください"
+
+#, csharp-format
+msgid "maMaterialHelper.guide.statusCopied"
+msgstr "「{0}」からコピー済み（{1}オブジェクト・{2}マテリアル）\n衣装を選択して手順2を実行してください"
 
 msgid "maMaterialHelper.noSetupGroups"
 msgstr "マテリアルセットアップのグループが見つかりませんでした"
@@ -72,7 +88,7 @@ msgstr ""
 "{0}\n"
 "\n"
 "解決方法:\n"
-"代わりに「Create Material Setter」を使用してください。"
+"代わりに「Create Color Menu」を使用してください。"
 
 #, csharp-format
 msgid "maMaterialHelper.swapLimitation.conflictHeader"
@@ -123,7 +139,7 @@ msgstr "検索..."
 
 msgid "slotRemap.description"
 msgstr ""
-"もちふぃった～等を利用し変換した際、Create Material Setterなどでの色変更がうまくマッピングされないときに利用してください。\n"
+"もちふぃった～等を利用し変換した際、Create Color Menuなどでの色変更がうまくマッピングされないときに利用してください。\n"
 "変換後の衣装のマテリアルスロットを参照元（変換前）の衣装に対応付け、"
 "Material Setter/Swapの色設定が正しいスロットに適用されるようにします。\n"
 "マッピングは変換直後、色改変（メッシュのマテリアル変更）を実施する前に生成してください。"

--- a/Editor/MAMaterialHelper/ColorMenuGuideWindow.cs
+++ b/Editor/MAMaterialHelper/ColorMenuGuideWindow.cs
@@ -1,0 +1,163 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using Kanameliser.Editor.MAMaterialHelper.Common;
+using Kanameliser.EditorPlus;
+
+namespace Kanameliser.Editor.MAMaterialHelper
+{
+    /// <summary>
+    /// Guide window explaining the two-step Color Menu workflow,
+    /// with a live view of the currently copied color data
+    /// </summary>
+    public class ColorMenuGuideWindow : EditorWindow
+    {
+        private const string StyleSheetPath =
+            "Packages/net.kanameliser.editor-plus/Editor/MAMaterialHelper/ColorMenuGuideWindow.uss";
+        private const long StatusPollIntervalMs = 500;
+
+        private VisualElement statusCard;
+        private Label statusLabel;
+        private ScrollView copiedListView;
+        private CopiedMaterialData lastSeenData;
+        private int copiedObjectCount;
+        private int copiedMaterialCount;
+
+        public static void ShowWindow()
+        {
+            var window = GetWindow<ColorMenuGuideWindow>();
+            window.titleContent = new GUIContent("How to Create Color Menu");
+            window.minSize = new Vector2(380, 320);
+        }
+
+        public void CreateGUI()
+        {
+            var root = rootVisualElement;
+
+            var styleSheet = AssetDatabase.LoadAssetAtPath<StyleSheet>(StyleSheetPath);
+            if (styleSheet != null)
+            {
+                root.styleSheets.Add(styleSheet);
+            }
+
+            var container = new VisualElement();
+            container.AddToClassList("guide-container");
+            root.Add(container);
+
+            // Language switcher at top
+            var langSwitcher = new IMGUIContainer(Localization.ShowLanguageUI);
+            langSwitcher.AddToClassList("language-switcher");
+            container.Add(langSwitcher);
+
+            var title = new Label("maMaterialHelper.guide.title");
+            title.AddToClassList("guide-title");
+            title.AddToClassList("ndmf-tr");
+            container.Add(title);
+
+            container.Add(CreateStepCard("1", "maMaterialHelper.guide.step1"));
+            container.Add(CreateStepCard("2", "maMaterialHelper.guide.step2"));
+
+            statusCard = new VisualElement();
+            statusCard.AddToClassList("status-card");
+
+            statusLabel = new Label();
+            statusLabel.AddToClassList("status-label");
+            statusCard.Add(statusLabel);
+
+            copiedListView = new ScrollView(ScrollViewMode.Vertical);
+            copiedListView.AddToClassList("copied-list");
+            statusCard.Add(copiedListView);
+
+            container.Add(statusCard);
+
+            // Polled so the view follows copy operations and language changes
+            UpdateStatus();
+            statusCard.schedule.Execute(UpdateStatus).Every(StatusPollIntervalMs);
+
+            Localization.LocalizeUIElements(root);
+        }
+
+        private static VisualElement CreateStepCard(string number, string textKey)
+        {
+            var card = new VisualElement();
+            card.AddToClassList("step-card");
+
+            var badge = new Label(number);
+            badge.AddToClassList("step-badge");
+            card.Add(badge);
+
+            var text = new Label(textKey);
+            text.AddToClassList("step-text");
+            text.AddToClassList("ndmf-tr");
+            card.Add(text);
+
+            return card;
+        }
+
+        private void UpdateStatus()
+        {
+            var data = MAMaterialHelperSession.HasCopiedData ? MAMaterialHelperSession.CopiedData : null;
+
+            // The list and counts only need rebuilding when the copied data itself changes
+            if (!ReferenceEquals(data, lastSeenData))
+            {
+                lastSeenData = data;
+                RebuildCopiedList(data);
+            }
+
+            // The text is refreshed every tick so it follows language changes
+            if (data != null)
+            {
+                statusLabel.text = Localization.S("maMaterialHelper.guide.statusCopied",
+                    data.sourceRootName, copiedObjectCount, copiedMaterialCount);
+                statusCard.AddToClassList("status-card--copied");
+            }
+            else
+            {
+                statusLabel.text = Localization.S("maMaterialHelper.guide.statusNotCopied");
+                statusCard.RemoveFromClassList("status-card--copied");
+            }
+        }
+
+        private void RebuildCopiedList(CopiedMaterialData data)
+        {
+            copiedListView.Clear();
+            copiedObjectCount = 0;
+            copiedMaterialCount = 0;
+
+            if (data == null)
+            {
+                copiedListView.style.display = DisplayStyle.None;
+                return;
+            }
+
+            copiedListView.style.display = DisplayStyle.Flex;
+
+            // Groups exclude the internal __GROUP_START_ marker entries
+            foreach (var group in MAMaterialHelperSession.GetCopiedDataGroups())
+            {
+                if (group.Count == 0) continue;
+
+                var groupName = string.IsNullOrEmpty(group[0].rootObjectName)
+                    ? data.sourceRootName
+                    : group[0].rootObjectName;
+
+                var foldout = new Foldout { text = $"{groupName} ({group.Count})", value = false };
+                foldout.AddToClassList("copied-group");
+
+                foreach (var setup in group)
+                {
+                    copiedObjectCount++;
+                    copiedMaterialCount += setup.materials.Length;
+
+                    var row = new Label($"{setup.objectName} ({setup.materials.Length})");
+                    row.AddToClassList("copied-list-item");
+                    row.tooltip = string.IsNullOrEmpty(setup.relativePath) ? setup.objectName : setup.relativePath;
+                    foldout.Add(row);
+                }
+
+                copiedListView.Add(foldout);
+            }
+        }
+    }
+}

--- a/Editor/MAMaterialHelper/ColorMenuGuideWindow.cs.meta
+++ b/Editor/MAMaterialHelper/ColorMenuGuideWindow.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8350e45b396a76b42adb1abdbbf96dfa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/MAMaterialHelper/ColorMenuGuideWindow.uss
+++ b/Editor/MAMaterialHelper/ColorMenuGuideWindow.uss
@@ -1,0 +1,89 @@
+.guide-container {
+    flex-grow: 1;
+    padding: 12px 16px 16px 16px;
+}
+
+.language-switcher {
+    margin-bottom: 6px;
+}
+
+.guide-title {
+    font-size: 14px;
+    -unity-font-style: bold;
+    margin-bottom: 10px;
+    white-space: normal;
+}
+
+.step-card {
+    flex-direction: row;
+    align-items: center;
+    background-color: var(--unity-colors-helpbox-background);
+    border-color: var(--unity-colors-helpbox-border);
+    border-width: 1px;
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-bottom: 8px;
+}
+
+.step-badge {
+    width: 22px;
+    height: 22px;
+    border-radius: 11px;
+    background-color: rgb(70, 115, 190);
+    color: white;
+    -unity-font-style: bold;
+    -unity-text-align: middle-center;
+    margin-right: 10px;
+    flex-shrink: 0;
+}
+
+.step-text {
+    flex-grow: 1;
+    flex-shrink: 1;
+    white-space: normal;
+}
+
+.status-card {
+    flex-shrink: 1;
+    background-color: var(--unity-colors-helpbox-background);
+    border-color: var(--unity-colors-helpbox-border);
+    border-width: 1px;
+    border-left-width: 3px;
+    border-left-color: rgb(140, 140, 140);
+    border-radius: 6px;
+    padding: 10px 12px;
+    margin-top: 4px;
+}
+
+.status-card--copied {
+    border-left-color: rgb(94, 180, 93);
+}
+
+.status-label {
+    white-space: normal;
+}
+
+.status-card--copied .status-label {
+    color: rgb(94, 180, 93);
+}
+
+.copied-list {
+    flex-shrink: 1;
+    max-height: 180px;
+    margin-top: 6px;
+    border-top-width: 1px;
+    border-top-color: var(--unity-colors-helpbox-border);
+    padding-top: 4px;
+}
+
+.copied-group {
+    margin-top: 2px;
+}
+
+.copied-group > .unity-foldout__toggle {
+    -unity-font-style: bold;
+}
+
+.copied-list-item {
+    padding: 1px 2px;
+}

--- a/Editor/MAMaterialHelper/ColorMenuGuideWindow.uss.meta
+++ b/Editor/MAMaterialHelper/ColorMenuGuideWindow.uss.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9c6dd01e47d5a54db1ec05188cc23b5
+ScriptedImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 2
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 
+  script: {fileID: 12385, guid: 0000000000000000e000000000000000, type: 0}
+  disableValidation: 0

--- a/Editor/MAMaterialHelper/MAMaterialHelperEditor.cs
+++ b/Editor/MAMaterialHelper/MAMaterialHelperEditor.cs
@@ -13,11 +13,12 @@ namespace Kanameliser.Editor.MAMaterialHelper
     /// </summary>
     public static class MAMaterialHelperEditor
     {
-        private const string MENU_PATH_COPY = "GameObject/Kanameliser Editor Plus/Copy Material Setup";
-        private const string MENU_PATH_CREATE_SETTER = "GameObject/Kanameliser Editor Plus/Create Material Setter";
-        private const string MENU_PATH_CREATE_SETTER_ALL_SLOTS = "GameObject/Kanameliser Editor Plus/[Optional] Create Material Setter (All Slots)";
-        private const string MENU_PATH_CREATE_SWAP = "GameObject/Kanameliser Editor Plus/Create Material Swap";
-        private const string MENU_PATH_CREATE_SWAP_PER_OBJECT = "GameObject/Kanameliser Editor Plus/[Optional] Create Material Swap (Per Object)";
+        private const string MENU_PATH_HOW_TO = "GameObject/Kanameliser Editor Plus/[How to Create Color Menu]";
+        private const string MENU_PATH_COPY = "GameObject/Kanameliser Editor Plus/Copy Color Variants";
+        private const string MENU_PATH_CREATE_SETTER = "GameObject/Kanameliser Editor Plus/Create Color Menu";
+        private const string MENU_PATH_CREATE_SETTER_ALL_SLOTS = "GameObject/Kanameliser Editor Plus/Advanced/Create Material Setter (All Slots)";
+        private const string MENU_PATH_CREATE_SWAP = "GameObject/Kanameliser Editor Plus/Advanced/Create Material Swap";
+        private const string MENU_PATH_CREATE_SWAP_PER_OBJECT = "GameObject/Kanameliser Editor Plus/Advanced/Create Material Swap (Per Object)";
         private const string MENU_PATH_ADD_REMAPPING = "GameObject/Kanameliser Editor Plus/Add Material Slot Remapping";
         private const int MENU_PRIORITY = 100;
 
@@ -46,6 +47,13 @@ namespace Kanameliser.Editor.MAMaterialHelper
             return Selection.activeGameObject != null;
         }
 
+        // +5 places this below the Advanced/ submenu, at the end of the color menu group
+        [MenuItem(MENU_PATH_HOW_TO, false, MENU_PRIORITY + 5)]
+        public static void OpenColorMenuGuide()
+        {
+            ColorMenuGuideWindow.ShowWindow();
+        }
+
         [MenuItem(MENU_PATH_COPY, false, MENU_PRIORITY)]
         public static void CopyMaterialSetup()
         {
@@ -72,8 +80,19 @@ namespace Kanameliser.Editor.MAMaterialHelper
                 string objectNames = selectedObjects.Length == 1
                     ? selectedObjects[0].name
                     : $"{selectedObjects.Length} objects";
-                MAMaterialHelperUtils.LogSuccess($"Copied material setup from {objectNames} ({copiedData.materialSetups.Count} material setups)");
-            }, "copy material setup");
+                MAMaterialHelperUtils.LogSuccess($"Copied color variants from {objectNames} ({copiedData.materialSetups.Count} material setups)");
+            }, "copy color variants");
+        }
+
+        /// <summary>
+        /// Returns true when copied data exists; otherwise shows a dialog guiding the user to copy first
+        /// </summary>
+        private static bool EnsureCopiedDataOrGuide()
+        {
+            if (MAMaterialHelperSession.HasCopiedData) return true;
+
+            MAMaterialHelperUtils.ShowInfoDialog(Localization.S("maMaterialHelper.noCopiedSetup"));
+            return false;
         }
 
         [MenuItem(MENU_PATH_CREATE_SETTER, false, MENU_PRIORITY + 1)]
@@ -81,12 +100,7 @@ namespace Kanameliser.Editor.MAMaterialHelper
         {
             var selected = Selection.activeGameObject;
             if (selected == null) return;
-
-            if (!MAMaterialHelperSession.HasCopiedData)
-            {
-                MAMaterialHelperUtils.ShowErrorDialog(Localization.S("maMaterialHelper.noCopiedSetup"));
-                return;
-            }
+            if (!EnsureCopiedDataOrGuide()) return;
 
             MAMaterialHelperUtils.TryExecute(() =>
             {
@@ -108,12 +122,7 @@ namespace Kanameliser.Editor.MAMaterialHelper
         {
             var selected = Selection.activeGameObject;
             if (selected == null) return;
-
-            if (!MAMaterialHelperSession.HasCopiedData)
-            {
-                MAMaterialHelperUtils.ShowErrorDialog(Localization.S("maMaterialHelper.noCopiedSetup"));
-                return;
-            }
+            if (!EnsureCopiedDataOrGuide()) return;
 
             MAMaterialHelperUtils.TryExecute(() =>
             {
@@ -135,12 +144,7 @@ namespace Kanameliser.Editor.MAMaterialHelper
         {
             var selected = Selection.activeGameObject;
             if (selected == null) return;
-
-            if (!MAMaterialHelperSession.HasCopiedData)
-            {
-                MAMaterialHelperUtils.ShowErrorDialog(Localization.S("maMaterialHelper.noCopiedSetup"));
-                return;
-            }
+            if (!EnsureCopiedDataOrGuide()) return;
 
             MAMaterialHelperUtils.TryExecute(() =>
             {
@@ -166,12 +170,7 @@ namespace Kanameliser.Editor.MAMaterialHelper
         {
             var selected = Selection.activeGameObject;
             if (selected == null) return;
-
-            if (!MAMaterialHelperSession.HasCopiedData)
-            {
-                MAMaterialHelperUtils.ShowErrorDialog(Localization.S("maMaterialHelper.noCopiedSetup"));
-                return;
-            }
+            if (!EnsureCopiedDataOrGuide()) return;
 
             MAMaterialHelperUtils.TryExecute(() =>
             {

--- a/README.ja.md
+++ b/README.ja.md
@@ -93,18 +93,22 @@ Modular Avatarのマテリアル制御コンポーネントを使用した色変
 
 #### 使い方
 
-1. カラーバリエーションPrefabを選択 → 右クリック → `Copy Material Setup`（複数選択可）
-2. ターゲットの衣装を選択 → 右クリック → 以下のいずれかを選択:
-   - `Create Material Setter` — 各スロットに直接マテリアルを設定（推奨）
-   - `[Optional] Create Material Setter (All Slots)` — すべてのスロットにSetterを作成（パフォーマンスに影響する可能性があるため、カスタマイズしたい場合のみ推奨）
-   - `Create Material Swap` — マテリアルの置き換えルールで設定
-   - `[Optional] Create Material Swap (Per Object)` — オブジェクト毎に個別のSwapを作成
+1. カラーバリエーションPrefabを選択 → 右クリック → `Copy Color Variants`（複数選択可）
+2. ターゲットの衣装を選択 → 右クリック → `Create Color Menu`（コピー後に表示されます）
 
-番号付きカラーバリエーション（Color1、Color2など）を含む「Color Menu」が自動作成されます。
+手順が分からなくなったときは、右クリックメニューの `[How to Create Color Menu]` を開くと、手順の説明とコピー済みオブジェクトの一覧をいつでも確認できます。
+
+番号付きカラーバリエーション（Color1、Color2など）を含む「Color Menu」が自動作成されます。`Create Color Menu` はModular AvatarのMaterial Setterコンポーネントをスロット単位で生成し、ほとんどのケースに対応できます。
+
+特殊なケース向けに、`Advanced` サブメニューで別の生成モードを選択できます:
+
+- `Create Material Setter (All Slots)` — すべてのスロットにSetterを作成（パフォーマンスに影響する可能性があるため、カスタマイズしたい場合のみ推奨）
+- `Create Material Swap` — マテリアルの置き換えルールで設定
+- `Create Material Swap (Per Object)` — オブジェクト毎に個別のSwapを作成
 
 #### Material SetterとMaterial Swapの違い
 
-基本的にはMaterial Setterを推奨します。
+基本的にはMaterial Setter（`Create Color Menu` が使用）を推奨します。
 
 - **Material Setter**: スロット単位で設定するため、同一メッシュ内で同じマテリアルからそれぞれ異なるマテリアルへの変更が可能
 - **Material Swap**: マテリアル名ベースで置き換えるため、同一マテリアルは同じ変更先になる。シンプルな構成向け
@@ -138,13 +142,13 @@ Material Swapは「マテリアルX」を1つのマテリアルにしか置き�
 
 1. 変換後の衣装を右クリック → `Add Material Slot Remapping`
 2. 元の衣装を `Reference Prefab` に指定 → `Generate Mapping` をクリック
-3. 通常どおり `Copy Material Setup` / `Create Material Setter` / `Create Material Swap` を実行 — 生成がマッピングに従い、色が正しいスロットに適用されます
+3. 通常どおり `Copy Color Variants` / `Create Color Menu` を実行 — 生成がマッピングに従い、色が正しいスロットに適用されます
 
 マッピングはマテリアル参照から生成されるため、変換直後の衣装のマテリアルを変更する前に実行し、Material Slot Remappingを生成してください。  
 生成後はスロットの対応付け（インデックス）のみ保持するため、生成後に衣装のマテリアルを変更してもマッピングは壊れません。
 同じマテリアル（または空のスロット）が複数ある場合はスロット順を一意に判定できないため、確認ダイアログと警告が表示されます。推定結果を確認し、必要に応じてInspectorで手動修正してください。
 
-アクセス: ヒエラルキー右クリック `Kanameliser Editor Plus > Add Material Slot Remapping / Copy Material Setup / Create Material Setter / Create Material Swap`
+アクセス: ヒエラルキー右クリック `Kanameliser Editor Plus > Copy Color Variants / Create Color Menu / Advanced / [How to Create Color Menu] / Add Material Slot Remapping`
 
 ### AO Bounds Setter
 

--- a/README.md
+++ b/README.md
@@ -95,18 +95,22 @@ Requirement: [Modular Avatar](https://modular-avatar.nadena.dev/) 1.13.0 or high
 
 #### Usage
 
-1. Select color variation prefabs → Right-click → `Copy Material Setup` (multiple selection supported)
-2. Select target outfit → Right-click → Choose one of the following:
-   - `Create Material Setter` — Directly set materials per slot (recommended)
-   - `[Optional] Create Material Setter (All Slots)` — Create setters for all slots (may affect performance, recommended only when you need to customize manually)
-   - `Create Material Swap` — Set materials by replacement rules
-   - `[Optional] Create Material Swap (Per Object)` — Create individual swaps per object
+1. Select color variation prefabs → Right-click → `Copy Color Variants` (multiple selection supported)
+2. Select target outfit → Right-click → `Create Color Menu` (this item appears after copying)
 
-A "Color Menu" with numbered color variations (Color1, Color2, etc.) is automatically created.
+If you are unsure of the steps, open `[How to Create Color Menu]` from the right-click menu at any time to review the workflow and see a list of the currently copied objects.
+
+A "Color Menu" with numbered color variations (Color1, Color2, etc.) is automatically created. `Create Color Menu` generates Modular Avatar Material Setter components per slot, which works for most cases.
+
+For special cases, the `Advanced` submenu offers alternative generation modes:
+
+- `Create Material Setter (All Slots)` — Create setters for all slots (may affect performance, recommended only when you need to customize manually)
+- `Create Material Swap` — Set materials by replacement rules
+- `Create Material Swap (Per Object)` — Create individual swaps per object
 
 #### Difference Between Material Setter and Material Swap
 
-Material Setter is recommended for most use cases.
+Material Setter (used by `Create Color Menu`) is recommended for most use cases.
 
 - **Material Setter**: Sets per slot, allowing different materials to be assigned from the same source material within the same mesh
 - **Material Swap**: Replaces by material name, so the same source material always maps to the same target. Best for simple configurations
@@ -140,13 +144,13 @@ When an outfit is converted to fit another avatar (e.g. with auto-fitting tools)
 
 1. Right-click the converted outfit → `Add Material Slot Remapping`
 2. Set the original outfit as `Reference Prefab` → click `Generate Mapping`
-3. Run `Copy Material Setup` / `Create Material Setter` / `Create Material Swap` as usual — generation follows the mapping so colors land on the correct slots
+3. Run `Copy Color Variants` / `Create Color Menu` as usual — generation follows the mapping so colors land on the correct slots
 
 The mapping is generated from material references, so generate it before changing the converted outfit's materials (i.e. right after conversion).  
 After generation, only the slot correspondence (indices) is stored, so changing the outfit's materials afterwards does not break the mapping.
 When the same material (or an empty slot) occurs more than once, the slot order cannot be determined uniquely. A confirmation dialog and warnings identify these cases; review the estimated mapping and adjust it manually in the Inspector when needed.
 
-Access: Right-click in Hierarchy `Kanameliser Editor Plus > Add Material Slot Remapping / Copy Material Setup / Create Material Setter / Create Material Swap`
+Access: Right-click in Hierarchy `Kanameliser Editor Plus > Copy Color Variants / Create Color Menu / Advanced / [How to Create Color Menu] / Add Material Slot Remapping`
 
 ### AO Bounds Setter
 

--- a/docs~/en/features/ma-material-helper.md
+++ b/docs~/en/features/ma-material-helper.md
@@ -6,17 +6,20 @@ Automatically generates color change menus using Modular Avatar's material contr
 
 ## Usage
 
-1. Select color variation prefabs → Right-click → `Copy Material Setup` (multiple selection supported)
-2. Select target outfit → Right-click → Choose one of the following:
+1. Select color variation prefabs → Right-click → `Copy Color Variants` (multiple selection supported)
+2. Select target outfit → Right-click → `Create Color Menu` (this item appears after copying)
+
+If you are unsure of the steps, open `[How to Create Color Menu]` from the right-click menu at any time to review the workflow and see a list of the currently copied objects.
+
+A "Color Menu" with numbered color variations (Color1, Color2, etc.) is automatically created. `Create Color Menu` generates Material Setter components per slot (**recommended** for most cases).
+
+For special cases, the `Advanced` submenu (shown after copying) offers alternative generation modes:
 
 | Command | Description |
 |---|---|
-| `Create Material Setter` | Set materials per slot (**recommended**) |
-| `[Optional] Create Material Setter (All Slots)` | Create setters for all slots (for manual customization) |
+| `Create Material Setter (All Slots)` | Create setters for all slots (for manual customization) |
 | `Create Material Swap` | Set materials by replacement rules |
-| `[Optional] Create Material Swap (Per Object)` | Create individual swaps per object |
-
-A "Color Menu" with numbered color variations (Color1, Color2, etc.) is automatically created.
+| `Create Material Swap (Per Object)` | Create individual swaps per object |
 
 ## Material Setter vs Material Swap
 
@@ -46,7 +49,7 @@ When an outfit is converted to fit another avatar (e.g. with auto-fitting tools)
 
 1. Right-click the converted outfit → `Add Material Slot Remapping`
 2. Set the original outfit as `Reference Prefab` → click `Generate Mapping`
-3. Run `Copy Material Setup` / `Create Material Setter` / `Create Material Swap` as usual — generation follows the mapping so colors land on the correct slots
+3. Run `Copy Color Variants` / `Create Color Menu` as usual — generation follows the mapping so colors land on the correct slots
 
 The mapping is generated from material references, so generate it before changing the converted outfit's materials (i.e. right after conversion).  
 After generation, only the slot correspondence (indices) is stored, so changing the outfit's materials afterwards does not break the mapping.
@@ -54,7 +57,7 @@ When the same material (or an empty slot) occurs more than once, the slot order 
 
 ## Access
 
-Right-click in Hierarchy → `Kanameliser Editor Plus > Add Material Slot Remapping / Copy Material Setup / Create Material Setter / Create Material Swap`
+Right-click in Hierarchy → `Kanameliser Editor Plus > Copy Color Variants / Create Color Menu / Advanced / [How to Create Color Menu] / Add Material Slot Remapping`
 
 ## Verbose Matching Logs
 

--- a/docs~/features/ma-material-helper.md
+++ b/docs~/features/ma-material-helper.md
@@ -6,17 +6,20 @@ Modular Avatar のマテリアル制御コンポーネントを使った色変�
 
 ## 使い方
 
-1. カラーバリエーション Prefab を選択 → 右クリック → `Copy Material Setup`（複数選択可）
-2. ターゲットの衣装を選択 → 右クリック → 以下のいずれかを選択:
+1. カラーバリエーション Prefab を選択 → 右クリック → `Copy Color Variants`（複数選択可）
+2. ターゲットの衣装を選択 → 右クリック → `Create Color Menu`（コピー後に表示されます）
+
+手順が分からなくなったときは、右クリックメニューの `[How to Create Color Menu]` を開くと、手順の説明とコピー済みオブジェクトの一覧をいつでも確認できます。
+
+番号付きカラーバリエーション（Color1、Color2など）を含む「Color Menu」が自動作成されます。`Create Color Menu` はMaterial Setterをスロット単位で生成します（ほとんどのケースで**推奨**）。
+
+特殊なケース向けに、`Advanced` サブメニュー（コピー後に表示）で別の生成モードを選択できます:
 
 | コマンド | 説明 |
 |---|---|
-| `Create Material Setter` | 各スロットに直接マテリアルを設定（**推奨**） |
-| `[Optional] Create Material Setter (All Slots)` | すべてのスロットに Setter を作成（カスタマイズ用） |
+| `Create Material Setter (All Slots)` | すべてのスロットに Setter を作成（カスタマイズ用） |
 | `Create Material Swap` | マテリアルの置き換えルールで設定 |
-| `[Optional] Create Material Swap (Per Object)` | オブジェクトごとに個別の Swap を作成 |
-
-番号付きカラーバリエーション（Color1、Color2 など）を含む「Color Menu」が自動作成されます。
+| `Create Material Swap (Per Object)` | オブジェクトごとに個別の Swap を作成 |
 
 ## Material Setter と Material Swap の違い
 
@@ -46,7 +49,7 @@ Material Swap は「マテリアルX」を1つのマテリアルにしか置き�
 
 1. 変換後の衣装を右クリック → `Add Material Slot Remapping`
 2. 元の衣装を `Reference Prefab` に指定 → `Generate Mapping` をクリック
-3. 通常どおり `Copy Material Setup` / `Create Material Setter` / `Create Material Swap` を実行 — 生成がマッピングに従い、色が正しいスロットに適用されます
+3. 通常どおり `Copy Color Variants` / `Create Color Menu` を実行 — 生成がマッピングに従い、色が正しいスロットに適用されます
 
 マッピングはマテリアル参照から生成されるため、変換直後の衣装のマテリアルを変更する前に実行し、Material Slot Remappingを生成してください。  
 生成後はスロットの対応付け（インデックス）のみ保持するため、生成後に衣装のマテリアルを変更してもマッピングは壊れません。
@@ -54,7 +57,7 @@ Material Swap は「マテリアルX」を1つのマテリアルにしか置き�
 
 ## アクセス方法
 
-ヒエラルキー右クリック → `Kanameliser Editor Plus > Add Material Slot Remapping / Copy Material Setup / Create Material Setter / Create Material Swap`
+ヒエラルキー右クリック → `Kanameliser Editor Plus > Copy Color Variants / Create Color Menu / Advanced / [How to Create Color Menu] / Add Material Slot Remapping`
 
 ## 詳細マッチングログ
 


### PR DESCRIPTION
## 概要

MA Material Helperの「コピー → 作成」の手順を忘れやすい・分かりづらいというフィードバックへの対応

- `Copy Material Setup` → `Copy Color Variants`、`Create Material Setter` → `Create Color Menu` に名称変更。コマンド名が内部コンポーネント名ではなく「色変更メニューを作る」という目的を表すようになり、`Copy Materials` とも混同しにくくなりました
- `[Optional]` 系とMaterial Swap系のコマンドを `Advanced` サブメニューに移動
- 色メニューグループの末尾に `[How to Create Color Menu]` ガイドウィンドウを追加（UI Toolkit製・日英ローカライズ対応）。2ステップの手順説明に加え、コピー状態とコピー済みオブジェクトの一覧（コピー元Prefabごとに折りたたみ）をリアルタイム表示します
- ガイドのオブジェクト数集計は内部の `__GROUP_START_` マーカー行を除外するようにし、従来のフラットなセッションデータで件数が水増しされる問題を回避しています
- en/ja ローカライズ文字列、README、`docs~`、CHANGELOG（日英両方）を更新
