### PR TITLE
refactor: replace TransformSelectorWindow IMGUI Escape handling with KeyDownEvent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **MA Material Helper: Clearer Hierarchy context menu naming** — Renamed `Copy Material Setup` to `Copy Color Variants` and `Create Material Setter` to `Create Color Menu`, so the commands describe the color-menu workflow instead of internal component names and are no longer confusable with `Copy Materials`. The `[Optional]` variants and Material Swap commands moved into an `Advanced` submenu.
+- **AO Bounds Setter: Transform selector fully migrated to UI Toolkit** — The remaining IMGUI code (Esc key handling) in the Transform selector popup was replaced with a UI Toolkit event callback. Closing with the Esc key works the same as before.
 
 ### Removed
 
@@ -57,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 変更
 
 - **MA Material Helper: 右クリックメニュー名の見直し** — `Copy Material Setup` を `Copy Color Variants` に、`Create Material Setter` を `Create Color Menu` に名称変更しました。コマンド名が内部コンポーネント名ではなく「色変更メニューを作る」という目的を表すようになり、`Copy Materials` とも混同しにくくなりました。あわせて `[Optional]` 系とMaterial Swap系のコマンドは `Advanced` サブメニューに移動しました。
+- **AO Bounds Setter: TransformセレクターをUI Toolkitへ完全移行** — Transformセレクターのポップアップに残っていたIMGUIコード（Escキー処理）をUI Toolkitのイベントコールバックに置き換えました。Escキーで閉じる動作は変わりません。
 
 ### 削除
 

--- a/Editor/AOBoundsSetter/TransformSelectorWindow.cs
+++ b/Editor/AOBoundsSetter/TransformSelectorWindow.cs
@@ -118,6 +118,16 @@ namespace Kanameliser.EditorPlus
             transformListScrollView.style.borderRightColor = TransformListBorderColor;
             root.Add(transformListScrollView);
 
+            // Close on Escape key
+            root.RegisterCallback<KeyDownEvent>(evt =>
+            {
+                if (evt.keyCode == KeyCode.Escape)
+                {
+                    evt.StopPropagation();
+                    Close();
+                }
+            }, TrickleDown.TrickleDown);
+
             RefreshTransformList();
 
             // Focus search field
@@ -223,15 +233,6 @@ namespace Kanameliser.EditorPlus
         {
             // Close window when it loses focus
             Close();
-        }
-
-        private void OnGUI()
-        {
-            if (Event.current.type == EventType.KeyDown && Event.current.keyCode == KeyCode.Escape)
-            {
-                Close();
-                Event.current.Use();
-            }
         }
     }
 }


### PR DESCRIPTION
## 概要
- TransformSelectorWindow に残っていた最後の IMGUI コード(Esc キーで閉じる `OnGUI`)を UI Toolkit の `KeyDownEvent` コールバック(TrickleDown)に置き換え
- これで AO Bounds Setter 系ウィンドウは完全に UI Toolkit のみに