### PR TITLE
refactor: migrate Material Slot Remapping inspector to UI Toolkit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **MA Material Helper: Clearer Hierarchy context menu naming** — Renamed `Copy Material Setup` to `Copy Color Variants` and `Create Material Setter` to `Create Color Menu`, so the commands describe the color-menu workflow instead of internal component names and are no longer confusable with `Copy Materials`. The `[Optional]` variants and Material Swap commands moved into an `Advanced` submenu.
+- **MA Material Helper: Material Slot Remapping Inspector migrated to UI Toolkit** — The Inspector was rebuilt with Unity's UI Toolkit. Mapping generation, slot editing, and the reset action work the same as before, and the UI now stays in sync with undo/redo and external changes.
 
 ### Removed
 
@@ -57,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### 変更
 
 - **MA Material Helper: 右クリックメニュー名の見直し** — `Copy Material Setup` を `Copy Color Variants` に、`Create Material Setter` を `Create Color Menu` に名称変更しました。コマンド名が内部コンポーネント名ではなく「色変更メニューを作る」という目的を表すようになり、`Copy Materials` とも混同しにくくなりました。あわせて `[Optional]` 系とMaterial Swap系のコマンドは `Advanced` サブメニューに移動しました。
+- **MA Material Helper: Material Slot RemappingのInspectorをUI Toolkitへ移行** — InspectorのUIをUnityのUI Toolkitで再構築しました。マッピング生成・スロット編集・リセットの動作は変わらず、Undo/Redoや外部からの変更にもUIが追従するようになりました。
 
 ### 削除
 

--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -188,6 +188,42 @@ msgstr "Slot Mappings ({0} renderers)"
 msgid "slotRemap.resetToIdentity"
 msgstr "Reset This Renderer To Identity"
 
+msgid "slotRemap.error.noComponent"
+msgstr "No MaterialSlotRemapping component."
+
+msgid "slotRemap.error.referenceNotSet"
+msgstr "Reference prefab is not set."
+
+#, csharp-format
+msgid "slotRemap.error.slotCountMismatch"
+msgstr "Slot count mismatch at '{0}': host {1} vs reference {2}."
+
+msgid "slotRemap.error.noMatchingRenderers"
+msgstr "No matching renderers found between host and reference."
+
+#, csharp-format
+msgid "slotRemap.warning.noMatchingRenderer"
+msgstr "No matching renderer in reference for '{0}'."
+
+#, csharp-format
+msgid "slotRemap.warning.unresolvedSlots"
+msgstr "Unresolved slot(s) at '{0}': [{1}] - no matching material in reference. Fix manually."
+
+#, csharp-format
+msgid "slotRemap.warning.ambiguousDetail"
+msgstr ""
+"Ambiguous slot mapping at '{0}' for {1}: host slots [{2}], reference slots [{3}]. "
+"Estimated host -> reference [{4}]"
+
+#, csharp-format
+msgid "slotRemap.warning.ambiguous"
+msgstr ""
+"{0}. The same material or empty value occurs more than once, so submesh "
+"correspondence cannot be determined automatically. Review the estimated mapping manually."
+
+msgid "slotRemap.materialNone"
+msgstr "(None / Missing)"
+
 # ── Component Manager ──
 
 msgid "componentManager.targetObject"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -187,6 +187,42 @@ msgstr "スロットマッピング（{0} 件のRenderer）"
 msgid "slotRemap.resetToIdentity"
 msgstr "このRendererをそのままの対応にリセット"
 
+msgid "slotRemap.error.noComponent"
+msgstr "MaterialSlotRemappingコンポーネントがありません。"
+
+msgid "slotRemap.error.referenceNotSet"
+msgstr "参照元Prefabが設定されていません。"
+
+#, csharp-format
+msgid "slotRemap.error.slotCountMismatch"
+msgstr "'{0}' のマテリアルスロット数が一致しません（変換後 {1} / 参照元 {2}）。"
+
+msgid "slotRemap.error.noMatchingRenderers"
+msgstr "変換後の衣装と参照元の間で対応するRendererが見つかりませんでした。"
+
+#, csharp-format
+msgid "slotRemap.warning.noMatchingRenderer"
+msgstr "'{0}' に対応するRendererが参照元に見つかりませんでした。"
+
+#, csharp-format
+msgid "slotRemap.warning.unresolvedSlots"
+msgstr "'{0}' のスロット [{1}] と一致するマテリアルが参照元にありません。手動で設定してください。"
+
+#, csharp-format
+msgid "slotRemap.warning.ambiguousDetail"
+msgstr ""
+"'{0}' の {1} のスロット対応が曖昧です: 変換後スロット [{2}]、参照元スロット [{3}]、"
+"推定対応（変換後 -> 参照元）[{4}]"
+
+#, csharp-format
+msgid "slotRemap.warning.ambiguous"
+msgstr ""
+"{0}。同じマテリアルまたは空のスロットが複数あるため、サブメッシュの対応関係を"
+"自動では決定できません。推定マッピングを手動で確認してください。"
+
+msgid "slotRemap.materialNone"
+msgstr "（なし / Missing）"
+
 # ── Component Manager ──
 
 msgid "componentManager.targetObject"

--- a/Editor/MaterialSlotRemapping/MaterialSlotRemapGenerator.cs
+++ b/Editor/MaterialSlotRemapping/MaterialSlotRemapGenerator.cs
@@ -1,10 +1,24 @@
 using System.Collections.Generic;
 using UnityEngine;
 using Kanameliser.Editor.MAMaterialHelper.Common;
+using Kanameliser.EditorPlus;
 using Kanameliser.EditorPlus.Runtime;
 
 namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
 {
+    /// <summary>
+    /// Structured description of one ambiguous material group on a renderer.
+    /// </summary>
+    public class AmbiguousSlotMappingInfo
+    {
+        public string rendererPath;
+        public Material material;
+        public List<int> hostSlots = new List<int>();
+        public List<int> referenceSlots = new List<int>();
+        /// <summary>Estimated reference slot per entry of <see cref="hostSlots"/> (-1 = none).</summary>
+        public List<int> estimatedReferenceSlots = new List<int>();
+    }
+
     /// <summary>
     /// Result of a <see cref="MaterialSlotRemapGenerator.Generate"/> call.
     /// </summary>
@@ -15,6 +29,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
         public List<string> errors = new List<string>();
         public List<string> warnings = new List<string>();
         public List<string> ambiguousMappingDetails = new List<string>();
+        public List<AmbiguousSlotMappingInfo> ambiguousMappings = new List<AmbiguousSlotMappingInfo>();
         public int matchedRendererCount;
         public bool hasAmbiguousMappings;
     }
@@ -35,12 +50,12 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
 
             if (component == null)
             {
-                result.errors.Add("No MaterialSlotRemapping component.");
+                result.errors.Add(Localization.S("slotRemap.error.noComponent"));
                 return result;
             }
             if (component.referencePrefab == null)
             {
-                result.errors.Add("Reference prefab is not set.");
+                result.errors.Add(Localization.S("slotRemap.error.referenceNotSet"));
                 return result;
             }
 
@@ -65,7 +80,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
 
                 if (refT == null)
                 {
-                    result.warnings.Add($"No matching renderer in reference for '{DisplayPath(relPath)}'.");
+                    result.warnings.Add(Localization.S("slotRemap.warning.noMatchingRenderer", DisplayPath(relPath)));
                     continue;
                 }
 
@@ -75,8 +90,9 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
 
                 if (hostMaterials.Length != refMaterials.Length)
                 {
-                    result.errors.Add(
-                        $"Slot count mismatch at '{DisplayPath(relPath)}': host {hostMaterials.Length} vs reference {refMaterials.Length}.");
+                    result.errors.Add(Localization.S(
+                        "slotRemap.error.slotCountMismatch",
+                        DisplayPath(relPath), hostMaterials.Length, refMaterials.Length));
                     continue;
                 }
 
@@ -84,33 +100,42 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
                 foreach (var ambiguity in FindAmbiguousMaterialGroups(hostMaterials, refMaterials))
                 {
                     var estimates = new List<string>();
+                    var estimatedSlots = new List<int>();
                     foreach (int hostSlot in ambiguity.hostSlots)
                     {
                         int referenceSlot = map[hostSlot];
+                        estimatedSlots.Add(referenceSlot);
                         estimates.Add($"{hostSlot} -> {(referenceSlot >= 0 ? referenceSlot.ToString() : "none")}");
                     }
 
                     string materialName = ambiguity.material == null
-                        ? "(None / Missing)"
+                        ? Localization.S("slotRemap.materialNone")
                         : $"'{ambiguity.material.name}'";
-                    string detail =
-                        $"Ambiguous slot mapping at '{DisplayPath(relPath)}' for {materialName}: " +
-                        $"host slots [{string.Join(", ", ambiguity.hostSlots)}], " +
-                        $"reference slots [{string.Join(", ", ambiguity.referenceSlots)}]. " +
-                        $"Estimated host -> reference [{string.Join(", ", estimates)}]";
-                    string warning =
-                        detail + ". " +
-                        "The same material or empty value occurs more than once, so submesh " +
-                        "correspondence cannot be determined automatically. Review the estimated mapping manually.";
-                    result.warnings.Add(warning);
+                    string detail = Localization.S(
+                        "slotRemap.warning.ambiguousDetail",
+                        DisplayPath(relPath),
+                        materialName,
+                        string.Join(", ", ambiguity.hostSlots),
+                        string.Join(", ", ambiguity.referenceSlots),
+                        string.Join(", ", estimates));
+                    result.warnings.Add(Localization.S("slotRemap.warning.ambiguous", detail));
                     result.ambiguousMappingDetails.Add(detail);
+                    result.ambiguousMappings.Add(new AmbiguousSlotMappingInfo
+                    {
+                        rendererPath = relPath,
+                        material = ambiguity.material,
+                        hostSlots = new List<int>(ambiguity.hostSlots),
+                        referenceSlots = new List<int>(ambiguity.referenceSlots),
+                        estimatedReferenceSlots = estimatedSlots,
+                    });
                     result.hasAmbiguousMappings = true;
                 }
 
                 if (unresolved.Count > 0)
                 {
-                    result.warnings.Add(
-                        $"Unresolved slot(s) at '{DisplayPath(relPath)}': [{string.Join(", ", unresolved)}] - no matching material in reference. Fix manually.");
+                    result.warnings.Add(Localization.S(
+                        "slotRemap.warning.unresolvedSlots",
+                        DisplayPath(relPath), string.Join(", ", unresolved)));
                 }
 
                 remaps.Add(new RendererSlotRemap
@@ -132,7 +157,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
 
             if (remaps.Count == 0)
             {
-                result.errors.Add("No matching renderers found between host and reference.");
+                result.errors.Add(Localization.S("slotRemap.error.noMatchingRenderers"));
                 result.success = false;
                 return result;
             }

--- a/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
+++ b/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
@@ -32,6 +32,10 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
             var component = (MaterialSlotRemapping)target;
             var root = new VisualElement();
 
+            // Language switcher at top (renders nothing without NDMF)
+            var langSwitcher = new IMGUIContainer(Localization.ShowLanguageUI);
+            root.Add(langSwitcher);
+
             _descriptionBox = new HelpBox(Localization.S("slotRemap.description"), HelpBoxMessageType.Info);
             root.Add(_descriptionBox);
 
@@ -73,6 +77,10 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
             root.TrackSerializedObjectValue(serializedObject, so => SyncFromComponent());
 
             Localization.RegisterLanguageChangeCallback(this, e => e.RefreshLocalizedTexts());
+
+            // Applies the language-specific font (proper Japanese bold weights); texts themselves
+            // are set directly via S(), so there are no ndmf-tr elements to translate here.
+            Localization.LocalizeUIElements(root);
 
             return root;
         }

--- a/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
+++ b/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using UnityEditor;
+using UnityEditor.UIElements;
 using UnityEngine;
+using UnityEngine.UIElements;
 using Kanameliser.Editor.MAMaterialHelper.Common;
 using Kanameliser.EditorPlus;
 using Kanameliser.EditorPlus.Runtime;
@@ -15,36 +17,86 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
         private RemapGenerationResult _lastResult;
         private readonly Dictionary<string, bool> _foldouts = new Dictionary<string, bool>();
 
-        public override void OnInspectorGUI()
+        private HelpBox _descriptionBox;
+        private ObjectField _referencePrefabField;
+        private Button _generateButton;
+        private VisualElement _messagesContainer;
+        private VisualElement _remapsContainer;
+
+        public override VisualElement CreateInspectorGUI()
         {
             var component = (MaterialSlotRemapping)target;
+            var root = new VisualElement();
 
-            EditorGUILayout.HelpBox(Localization.S("slotRemap.description"), MessageType.Info);
+            _descriptionBox = new HelpBox(Localization.S("slotRemap.description"), HelpBoxMessageType.Info);
+            root.Add(_descriptionBox);
 
-            EditorGUILayout.Space();
-
-            EditorGUI.BeginChangeCheck();
-            var newRef = (GameObject)EditorGUILayout.ObjectField(
-                Localization.S("slotRemap.referencePrefab"), component.referencePrefab, typeof(GameObject), true);
-            if (EditorGUI.EndChangeCheck())
+            _referencePrefabField = new ObjectField(Localization.S("slotRemap.referencePrefab"))
+            {
+                objectType = typeof(GameObject),
+                allowSceneObjects = true
+            };
+            _referencePrefabField.AddToClassList(ObjectField.alignedFieldUssClassName);
+            _referencePrefabField.style.marginTop = 8;
+            _referencePrefabField.SetValueWithoutNotify(component.referencePrefab);
+            _referencePrefabField.RegisterValueChangedCallback(evt =>
             {
                 Undo.RecordObject(component, "Set Reference Prefab");
-                component.referencePrefab = newRef;
+                component.referencePrefab = evt.newValue as GameObject;
                 CommitChange(component);
-            }
+                UpdateGenerateButtonState();
+            });
+            root.Add(_referencePrefabField);
 
-            using (new EditorGUI.DisabledScope(component.referencePrefab == null))
+            _generateButton = new Button(() => GenerateMapping(component))
             {
-                if (GUILayout.Button(Localization.S("slotRemap.generateMapping")))
-                {
-                    GenerateMapping(component);
-                }
-            }
+                text = Localization.S("slotRemap.generateMapping")
+            };
+            root.Add(_generateButton);
 
-            DrawResultMessages();
+            _messagesContainer = new VisualElement();
+            root.Add(_messagesContainer);
 
-            EditorGUILayout.Space();
-            DrawRemaps(component);
+            _remapsContainer = new VisualElement();
+            _remapsContainer.style.marginTop = 8;
+            root.Add(_remapsContainer);
+
+            UpdateGenerateButtonState();
+            RebuildRemaps();
+
+            // Keep the UI in sync with undo/redo and external modifications
+            root.TrackSerializedObjectValue(serializedObject, so => SyncFromComponent());
+
+            Localization.RegisterLanguageChangeCallback(this, e => e.RefreshLocalizedTexts());
+
+            return root;
+        }
+
+        private void SyncFromComponent()
+        {
+            if (target == null) return;
+
+            var component = (MaterialSlotRemapping)target;
+            _referencePrefabField.SetValueWithoutNotify(component.referencePrefab);
+            UpdateGenerateButtonState();
+            RebuildRemaps();
+        }
+
+        private void RefreshLocalizedTexts()
+        {
+            if (_descriptionBox == null || target == null) return;
+
+            _descriptionBox.text = Localization.S("slotRemap.description");
+            _referencePrefabField.label = Localization.S("slotRemap.referencePrefab");
+            _generateButton.text = Localization.S("slotRemap.generateMapping");
+            UpdateMessages();
+            RebuildRemaps();
+        }
+
+        private void UpdateGenerateButtonState()
+        {
+            var component = (MaterialSlotRemapping)target;
+            _generateButton.SetEnabled(component.referencePrefab != null);
         }
 
         private void GenerateMapping(MaterialSlotRemapping component)
@@ -61,6 +113,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
                         Localization.S("common.cancel")))
                 {
                     _lastResult = null;
+                    UpdateMessages();
                     return;
                 }
 
@@ -69,6 +122,9 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
                 CommitChange(component);
                 Debug.Log($"[MA Material Helper] Generated slot remapping for {result.matchedRendererCount} renderer(s).");
             }
+
+            UpdateMessages();
+            RebuildRemaps();
         }
 
         internal static string BuildAmbiguityConfirmationMessage(RemapGenerationResult result)
@@ -91,28 +147,42 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
             return Localization.S("slotRemap.ambiguousDialog.message", details);
         }
 
-        private void DrawResultMessages()
+        private void UpdateMessages()
         {
+            _messagesContainer.Clear();
+
             if (_lastResult == null) return;
 
             foreach (var error in _lastResult.errors)
-                EditorGUILayout.HelpBox(error, MessageType.Error);
+                _messagesContainer.Add(new HelpBox(error, HelpBoxMessageType.Error));
             foreach (var warning in _lastResult.warnings)
-                EditorGUILayout.HelpBox(warning, MessageType.Warning);
+                _messagesContainer.Add(new HelpBox(warning, HelpBoxMessageType.Warning));
 
             if (_lastResult.success && _lastResult.warnings.Count == 0 && _lastResult.errors.Count == 0)
-                EditorGUILayout.HelpBox(Localization.S("slotRemap.mappingGenerated", _lastResult.matchedRendererCount), MessageType.Info);
+            {
+                _messagesContainer.Add(new HelpBox(
+                    Localization.S("slotRemap.mappingGenerated", _lastResult.matchedRendererCount),
+                    HelpBoxMessageType.Info));
+            }
         }
 
-        private void DrawRemaps(MaterialSlotRemapping component)
+        private void RebuildRemaps()
         {
+            _remapsContainer.Clear();
+
+            var component = (MaterialSlotRemapping)target;
             if (component.remaps == null || component.remaps.Count == 0)
             {
-                EditorGUILayout.LabelField(Localization.S("slotRemap.noMapping"), EditorStyles.miniLabel);
+                var noMappingLabel = new Label(Localization.S("slotRemap.noMapping"));
+                noMappingLabel.style.fontSize = 10;
+                noMappingLabel.style.opacity = 0.8f;
+                _remapsContainer.Add(noMappingLabel);
                 return;
             }
 
-            EditorGUILayout.LabelField(Localization.S("slotRemap.slotMappings", component.remaps.Count), EditorStyles.boldLabel);
+            var headerLabel = new Label(Localization.S("slotRemap.slotMappings", component.remaps.Count));
+            headerLabel.style.unityFontStyleAndWeight = FontStyle.Bold;
+            _remapsContainer.Add(headerLabel);
 
             foreach (var remap in component.remaps)
             {
@@ -121,21 +191,32 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
                 string key = remap.rendererPath ?? "";
                 if (!_foldouts.ContainsKey(key)) _foldouts[key] = false;
 
-                string title = DisplayPath(component, remap);
-                _foldouts[key] = EditorGUILayout.Foldout(_foldouts[key], title, true);
-                if (!_foldouts[key]) continue;
-
-                EditorGUI.indentLevel++;
-                DrawRemapEntry(component, remap);
-                if (GUILayout.Button(Localization.S("slotRemap.resetToIdentity"), GUILayout.Width(260)))
+                var foldout = new Foldout
                 {
-                    ResetToIdentity(component, remap);
-                }
-                EditorGUI.indentLevel--;
+                    text = DisplayPath(component, remap),
+                    value = _foldouts[key]
+                };
+                foldout.RegisterValueChangedCallback(evt =>
+                {
+                    if (evt.target == foldout)
+                        _foldouts[key] = evt.newValue;
+                });
+
+                BuildRemapEntry(foldout.contentContainer, component, remap);
+
+                var resetButton = new Button(() => ResetToIdentity(component, remap))
+                {
+                    text = Localization.S("slotRemap.resetToIdentity")
+                };
+                resetButton.style.width = 260;
+                resetButton.style.alignSelf = Align.FlexStart;
+                foldout.contentContainer.Add(resetButton);
+
+                _remapsContainer.Add(foldout);
             }
         }
 
-        private void DrawRemapEntry(MaterialSlotRemapping component, RendererSlotRemap remap)
+        private void BuildRemapEntry(VisualElement container, MaterialSlotRemapping component, RendererSlotRemap remap)
         {
             var map = remap.referenceSlotForHostSlot;
             if (map == null) return;
@@ -143,9 +224,8 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
             var hostMaterials = GetHostMaterials(component, remap);
             int refCount = map.Length;
 
-            var options = new string[refCount + 1];
-            options[0] = "(none)";
-            for (int i = 0; i < refCount; i++) options[i + 1] = $"Ref slot {i}";
+            var options = new List<string>(refCount + 1) { "(none)" };
+            for (int i = 0; i < refCount; i++) options.Add($"Ref slot {i}");
 
             for (int hostSlot = 0; hostSlot < map.Length; hostSlot++)
             {
@@ -156,14 +236,22 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
                 int current = map[hostSlot];
                 int popupIndex = (current >= 0 && current < refCount) ? current + 1 : 0;
 
-                int newPopup = EditorGUILayout.Popup($"Host slot {hostSlot} [{hostName}]", popupIndex, options);
-                int newValue = newPopup == 0 ? -1 : newPopup - 1;
-                if (newValue != current)
+                var dropdown = new DropdownField($"Host slot {hostSlot} [{hostName}]", options, popupIndex);
+                dropdown.AddToClassList(DropdownField.alignedFieldUssClassName);
+
+                int capturedHostSlot = hostSlot;
+                dropdown.RegisterValueChangedCallback(evt =>
                 {
-                    Undo.RecordObject(component, "Edit Slot Remapping");
-                    map[hostSlot] = newValue;
-                    CommitChange(component);
-                }
+                    int newValue = dropdown.index <= 0 ? -1 : dropdown.index - 1;
+                    if (newValue != map[capturedHostSlot])
+                    {
+                        Undo.RecordObject(component, "Edit Slot Remapping");
+                        map[capturedHostSlot] = newValue;
+                        CommitChange(component);
+                    }
+                });
+
+                container.Add(dropdown);
             }
         }
 
@@ -175,6 +263,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
             for (int i = 0; i < remap.referenceSlotForHostSlot.Length; i++)
                 remap.referenceSlotForHostSlot[i] = i;
             CommitChange(component);
+            RebuildRemaps();
         }
 
         /// <summary>

--- a/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
+++ b/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
@@ -14,7 +14,11 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
     {
         private const int MaxAmbiguityDetailsInDialog = 5;
 
-        private RemapGenerationResult _lastResult;
+        // Keyed by component instance ID so results survive the editor instance being destroyed
+        // when the selection changes (cleared on domain reload).
+        private static readonly Dictionary<int, RemapGenerationResult> lastResults =
+            new Dictionary<int, RemapGenerationResult>();
+
         private readonly Dictionary<string, bool> _foldouts = new Dictionary<string, bool>();
 
         private HelpBox _descriptionBox;
@@ -62,6 +66,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
             root.Add(_remapsContainer);
 
             UpdateGenerateButtonState();
+            UpdateMessages();
             RebuildRemaps();
 
             // Keep the UI in sync with undo/redo and external modifications
@@ -102,7 +107,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
         private void GenerateMapping(MaterialSlotRemapping component)
         {
             var result = MaterialSlotRemapGenerator.Generate(component);
-            _lastResult = result;
+            lastResults[component.GetInstanceID()] = result;
             if (result.success)
             {
                 if (result.hasAmbiguousMappings &&
@@ -112,7 +117,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
                         Localization.S("slotRemap.ambiguousDialog.useEstimated"),
                         Localization.S("common.cancel")))
                 {
-                    _lastResult = null;
+                    lastResults.Remove(component.GetInstanceID());
                     UpdateMessages();
                     return;
                 }
@@ -151,17 +156,18 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
         {
             _messagesContainer.Clear();
 
-            if (_lastResult == null) return;
+            if (target == null) return;
+            if (!lastResults.TryGetValue(target.GetInstanceID(), out var lastResult)) return;
 
-            foreach (var error in _lastResult.errors)
+            foreach (var error in lastResult.errors)
                 _messagesContainer.Add(new HelpBox(error, HelpBoxMessageType.Error));
-            foreach (var warning in _lastResult.warnings)
+            foreach (var warning in lastResult.warnings)
                 _messagesContainer.Add(new HelpBox(warning, HelpBoxMessageType.Warning));
 
-            if (_lastResult.success && _lastResult.warnings.Count == 0 && _lastResult.errors.Count == 0)
+            if (lastResult.success && lastResult.warnings.Count == 0 && lastResult.errors.Count == 0)
             {
                 _messagesContainer.Add(new HelpBox(
-                    Localization.S("slotRemap.mappingGenerated", _lastResult.matchedRendererCount),
+                    Localization.S("slotRemap.mappingGenerated", lastResult.matchedRendererCount),
                     HelpBoxMessageType.Info));
             }
         }

--- a/Editor/Tests/MaterialSlotRemapGeneratorTests.cs
+++ b/Editor/Tests/MaterialSlotRemapGeneratorTests.cs
@@ -107,11 +107,16 @@ namespace Kanameliser.EditorPlus.Tests
             Assert.That(result.hasAmbiguousMappings, Is.True);
             Assert.That(result.remaps[0].referenceSlotForHostSlot, Is.EqualTo(new[] { 1, 2, 0 }));
             Assert.That(result.ambiguousMappingDetails, Has.Count.EqualTo(1));
+            Assert.That(result.ambiguousMappings, Has.Count.EqualTo(1));
+            var ambiguity = result.ambiguousMappings[0];
+            Assert.That(ambiguity.hostSlots, Is.EqualTo(new[] { 0, 1 }));
+            Assert.That(ambiguity.referenceSlots, Is.EqualTo(new[] { 1, 2 }));
+            Assert.That(ambiguity.estimatedReferenceSlots, Is.EqualTo(new[] { 1, 2 }));
             StringAssert.Contains(
-                "host slots [0, 1], reference slots [1, 2]",
+                result.ambiguousMappingDetails[0],
                 string.Join("\n", result.warnings));
             StringAssert.Contains(
-                "Estimated host -> reference [0 -> 1, 1 -> 2]",
+                result.ambiguousMappingDetails[0],
                 MaterialSlotRemappingEditor.BuildAmbiguityConfirmationMessage(result));
         }
 
@@ -135,7 +140,8 @@ namespace Kanameliser.EditorPlus.Tests
             Assert.That(result.success, Is.True);
             Assert.That(result.hasAmbiguousMappings, Is.True);
             Assert.That(result.remaps[0].referenceSlotForHostSlot, Is.EqualTo(new[] { 1, 2, 0 }));
-            StringAssert.Contains("(None / Missing)", string.Join("\n", result.warnings));
+            Assert.That(result.ambiguousMappings, Has.Count.EqualTo(1));
+            Assert.That(result.ambiguousMappings[0].material, Is.Null);
         }
 
         [Test]

--- a/Runtime/MaterialSlotRemapping.cs
+++ b/Runtime/MaterialSlotRemapping.cs
@@ -15,6 +15,7 @@ namespace Kanameliser.EditorPlus.Runtime
     /// The component does nothing at runtime and is removed during avatar build (NDMF pass, plus the
     /// VRChat SDK strips non-whitelisted components as a backstop).
     /// </summary>
+    [AddComponentMenu("Kanameliser Editor Plus/Material Slot Remapping")]
     [DisallowMultipleComponent]
     public class MaterialSlotRemapping : MonoBehaviour
     {


### PR DESCRIPTION
## 概要

Material Slot RemappingのInspectorをUI Toolkitへ移行し、あわせてローカライズ周りの仕上げを行いました。

- **InspectorをUI Toolkitで再構築** — マッピング生成・スロット編集・リセットの動作は従来どおり。`TrackSerializedObjectValue` によりUndo/Redoや外部からの変更にもUIが追従するようになりました
- **生成メッセージのローカライズ対応** — Generatorが組み立てる警告・エラー（Unresolved slot / Ambiguous slot mapping / Slot count mismatch 等）を `Localization` 経由に変更し、`slotRemap.error.*` / `slotRemap.warning.*` キーを en/ja の .po に追加。曖昧マッピング確認ダイアログの詳細文も日本語化されます
- **結果メッセージが消える問題を修正** — 生成結果をEditorインスタンスのフィールドではなく、コンポーネントInstanceIDをキーにしたstatic Dictionaryで保持。別オブジェクトを選択して戻ってもメッセージが再表示されます（ドメインリロードでクリア）
- **NDMF言語スイッチャーをInspector上部に追加** — 他のローカライズ済みウィンドウと同じ `IMGUIContainer` パターン。
- **言語別フォントの適用** — `LocalizeUIElements(root)` を呼ぶことで `LanguagePrefs.ApplyFontPreferences` が効き、日本語boldの疑似ボールド描画が改善されます
- **Add Componentメニューの整理** — `[AddComponentMenu]` を追加し、「Scripts > Kanameliser.EditorPlus.Runtime」ではなく「Kanameliser Editor Plus」配下に表示
- **テストの言語非依存化** — `RemapGenerationResult.ambiguousMappings`（構造化データ）を追加し、英語メッセージの部分文字列ではなく hostSlots / referenceSlots / 推定対応を直接アサートするように変更