### PR TITLE
fix: UI Toolkit migration follow-ups for Component Manager and Slot Remapping

### DIFF
--- a/Editor/AOBoundsSetter/TransformSelectorWindow.cs
+++ b/Editor/AOBoundsSetter/TransformSelectorWindow.cs
@@ -222,6 +222,7 @@ namespace Kanameliser.EditorPlus
             // Single-click to select
             item.RegisterCallback<MouseDownEvent>(evt =>
             {
+                if (evt.button != 0) return;
                 onSelectionChanged?.Invoke(transform);
                 Close();
             });

--- a/Editor/ComponentManager.cs
+++ b/Editor/ComponentManager.cs
@@ -515,13 +515,21 @@ namespace Kanameliser.EditorPlus
             var nameLabel = new Label(gameObject.name);
             nameLabel.AddToClassList("go-name-label");
             nameLabel.AddToClassList("clickable-label");
-            nameLabel.RegisterCallback<MouseDownEvent>(evt => SelectGameObjectInHierarchy(gameObject));
+            nameLabel.RegisterCallback<MouseDownEvent>(evt =>
+            {
+                if (evt.button != 0) return;
+                SelectGameObjectInHierarchy(gameObject);
+            });
             gameObjectInfo.Add(nameLabel);
 
             var pathLabel = new Label(ComponentPathUtility.GetGameObjectPath(gameObject, targetObject));
             pathLabel.AddToClassList("go-path-label");
             pathLabel.AddToClassList("clickable-label");
-            pathLabel.RegisterCallback<MouseDownEvent>(evt => SelectGameObjectInHierarchy(gameObject));
+            pathLabel.RegisterCallback<MouseDownEvent>(evt =>
+            {
+                if (evt.button != 0) return;
+                SelectGameObjectInHierarchy(gameObject);
+            });
             gameObjectInfo.Add(pathLabel);
 
             gameObjectCell.Add(gameObjectInfo);

--- a/Editor/ComponentManager.cs
+++ b/Editor/ComponentManager.cs
@@ -37,6 +37,7 @@ namespace Kanameliser.EditorPlus
         private HelpBox selectPromptBox;
         private Button selectButton;
         private Button removeButton;
+        private IVisualElementScheduledItem filterRebuildSchedule;
 
         // Rows currently displayed, kept for in-place toggle updates
         private List<GameObject> currentFilteredGameObjects = new List<GameObject>();
@@ -95,6 +96,9 @@ namespace Kanameliser.EditorPlus
 
             // Re-clamp column widths when the window is resized
             root.RegisterCallback<GeometryChangedEvent>(evt => ApplyColumnWidth(gameObjectColumnWidth));
+
+            filterRebuildSchedule = root.schedule.Execute(RebuildTable);
+            filterRebuildSchedule.Pause();
 
             RebuildTable();
 
@@ -223,7 +227,7 @@ namespace Kanameliser.EditorPlus
             gameObjectFilterField.RegisterValueChangedCallback(evt =>
             {
                 gameObjectFilter = evt.newValue ?? "";
-                RebuildTable();
+                ScheduleFilterRebuild();
             });
             gameObjectFilterColumn.Add(gameObjectFilterField);
 
@@ -268,7 +272,7 @@ namespace Kanameliser.EditorPlus
             componentFilterField.RegisterValueChangedCallback(evt =>
             {
                 componentFilter = evt.newValue ?? "";
-                RebuildTable();
+                ScheduleFilterRebuild();
             });
             componentColumn.Add(componentFilterField);
 
@@ -437,6 +441,14 @@ namespace Kanameliser.EditorPlus
         }
 
         // ── Table building ──
+
+        /// <summary>
+        /// Debounces filter input so fast typing does not rebuild the table on every keystroke
+        /// </summary>
+        private void ScheduleFilterRebuild()
+        {
+            filterRebuildSchedule.ExecuteLater(ComponentConstants.FILTER_DEBOUNCE_MS);
+        }
 
         private void RebuildTable()
         {

--- a/Editor/ComponentManager/ComponentConstants.cs
+++ b/Editor/ComponentManager/ComponentConstants.cs
@@ -16,6 +16,7 @@ namespace Kanameliser.EditorPlus
         public const float RESIZE_HANDLE_WIDTH = 8f;
         public const float COLUMN_MARGIN = 20f;
         public const float MAX_COLUMN_RATIO = 0.6f;
+        public const long FILTER_DEBOUNCE_MS = 200;
     }
 
 }

--- a/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
+++ b/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
@@ -15,7 +15,7 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
         private const int MaxAmbiguityDetailsInDialog = 5;
 
         // Keyed by component instance ID so results survive the editor instance being destroyed
-        // when the selection changes (cleared on domain reload).
+        // when the selection changes (pruned for destroyed components, cleared on domain reload).
         private static readonly Dictionary<int, RemapGenerationResult> lastResults =
             new Dictionary<int, RemapGenerationResult>();
 
@@ -46,8 +46,30 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
                 UpdateMessages();
         }
 
+        /// <summary>
+        /// Drops results whose component no longer exists so the static cache does not grow
+        /// for the lifetime of the editor session
+        /// </summary>
+        private static void PruneDestroyedComponentResults()
+        {
+            if (lastResults.Count == 0) return;
+
+            List<int> stale = null;
+            foreach (int instanceId in lastResults.Keys)
+            {
+                if (EditorUtility.InstanceIDToObject(instanceId) == null)
+                    (stale ??= new List<int>()).Add(instanceId);
+            }
+
+            if (stale == null) return;
+            foreach (int instanceId in stale)
+                lastResults.Remove(instanceId);
+        }
+
         public override VisualElement CreateInspectorGUI()
         {
+            PruneDestroyedComponentResults();
+
             var component = (MaterialSlotRemapping)target;
             var root = new VisualElement();
 

--- a/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
+++ b/Editor/MaterialSlotRemapping/MaterialSlotRemappingEditor.cs
@@ -27,6 +27,25 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
         private VisualElement _messagesContainer;
         private VisualElement _remapsContainer;
 
+        private void OnEnable()
+        {
+            Undo.undoRedoPerformed += OnUndoRedoPerformed;
+        }
+
+        private void OnDisable()
+        {
+            Undo.undoRedoPerformed -= OnUndoRedoPerformed;
+        }
+
+        private void OnUndoRedoPerformed()
+        {
+            // Undo/redo may revert the remaps the last generation produced, so the stored
+            // result no longer describes the component state and must not stay on screen
+            if (target == null) return;
+            if (lastResults.Remove(target.GetInstanceID()))
+                UpdateMessages();
+        }
+
         public override VisualElement CreateInspectorGUI()
         {
             var component = (MaterialSlotRemapping)target;
@@ -162,6 +181,9 @@ namespace Kanameliser.Editor.MAMaterialHelper.SlotRemapping
 
         private void UpdateMessages()
         {
+            // Undo can fire before the inspector UI is built
+            if (_messagesContainer == null) return;
+
             _messagesContainer.Clear();
 
             if (target == null) return;


### PR DESCRIPTION
## 概要

UI Toolkit移行後のフォローアップ

- **Component Manager: フィルター入力をデバウンス** — これまで1文字入力するごとにテーブル全行を破棄・再生成していたため、オブジェクト数の多いアバターで入力がもたつく可能性がありました。`schedule.ExecuteLater` による200msのデバウンスを入れ、入力が落ち着いてから1回だけ再構築するようにしました。
- **クリック可能な行の左クリック判定** — Component Managerの名前/パスラベルと、AO Bounds SetterのTransformセレクター項目が `MouseDownEvent` のボタン種別を見ていなかったため、右・中クリックでもHierarchy選択やTransform確定+ポップアップクローズが発動していました。左クリックのみ受け付けるようにしました。
- **Material Slot Remapping: Undo/Redo後の古い結果メッセージをクリア** — マッピング生成後にUndoすると、マッピング一覧は空に戻るのに「Generated slot remapping for N renderer(s)」の成功メッセージが残り、表示が矛盾していました。`Undo.undoRedoPerformed` を購読し、Undo/Redo時に保持していた生成結果を破棄してメッセージを更新するようにしました。
- **Material Slot Remapping: 生成結果キャッシュの掃除** — 再選択をまたいで結果を保持するための静的Dictionary（`lastResults`）が、コンポーネント削除後もエントリを持ち続けていました。Inspector構築時に破棄済みコンポーネントのエントリを削除するようにしました（再選択で結果が残る挙動は維持）。