### PR TITLE
ci: split docs site into stable and beta channels

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,26 @@
+# Docs site deployment
+#
+# Channels:
+#   - Site root serves the stable docs, built from the `docs-release` branch.
+#     The branch is force-updated to the release tag automatically whenever a
+#     stable (x.y.z) release is published. For docs-only fixes, cherry-pick the
+#     fix onto `docs-release` and push — the site rebuilds without a release.
+#     Always land the same fix on main so the next release keeps it.
+#   - /beta/ serves the latest pre-release docs, built from the newest
+#     pre-release tag when it is newer than the stable release.
+#   - Until a stable release contains docs~, the pre-release docs serve as root.
+
 name: Deploy docs
 
 on:
   release:
     types: [published]
+  push:
+    branches: [docs-release]
   workflow_dispatch:
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 
@@ -14,11 +28,16 @@ concurrency:
   group: pages
   cancel-in-progress: false
 
+env:
+  SITE_BASE: /kanameliser-editor-plus/
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:
@@ -29,17 +48,120 @@ jobs:
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
 
-      - name: Install dependencies
-        run: npm ci
-        working-directory: docs~
+      - name: Sync docs-release branch to stable release tag
+        if: github.event_name == 'release'
+        run: |
+          tag="${{ github.event.release.tag_name }}"
+          if ! echo "$tag" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "Tag $tag is not a stable release — skipping sync"
+            exit 0
+          fi
+          if ! git cat-file -e "$tag:docs~/package.json" 2>/dev/null; then
+            echo "Tag $tag does not contain docs~ — skipping sync"
+            exit 0
+          fi
 
-      - name: Build docs
-        run: npm run docs:build
-        working-directory: docs~
+          # Never move the branch backwards (e.g. when re-publishing an old release)
+          if git rev-parse -q --verify origin/docs-release >/dev/null 2>&1; then
+            current=$(git show origin/docs-release:package.json | jq -r .version)
+            newest=$(printf '%s\n%s\n' "$current" "$tag" | sort -V | tail -n 1)
+            if [ "$newest" != "$tag" ] || [ "$tag" = "$current" ]; then
+              echo "docs-release is already at $current — skipping sync"
+              exit 0
+            fi
+          fi
+
+          commit=$(git rev-parse "$tag^{commit}")
+          git push --force origin "$commit:refs/heads/docs-release"
+          git update-ref refs/remotes/origin/docs-release "$commit"
+          echo "Synced docs-release to $tag ($commit)"
+
+      - name: Resolve docs versions
+        id: versions
+        run: |
+          root_ref=""
+          root_channel="stable"
+          stable_version=""
+
+          if git rev-parse -q --verify origin/docs-release >/dev/null 2>&1 \
+            && git cat-file -e origin/docs-release:docs~/package.json 2>/dev/null; then
+            root_ref="origin/docs-release"
+            stable_version=$(git show origin/docs-release:package.json | jq -r .version)
+          fi
+
+          beta=""
+          for tag in $(git tag --list | grep -E '^[0-9]+\.[0-9]+\.[0-9]+-' | sort -rV); do
+            if git cat-file -e "$tag:docs~/package.json" 2>/dev/null; then
+              beta="$tag"
+              break
+            fi
+          done
+
+          # Drop the beta when it is not newer than the stable release
+          if [ -n "$stable_version" ] && [ -n "$beta" ]; then
+            beta_base="${beta%%-*}"
+            newest=$(printf '%s\n%s\n' "$stable_version" "$beta_base" | sort -V | tail -n 1)
+            if [ "$newest" = "$stable_version" ]; then
+              beta=""
+            fi
+          fi
+
+          # Until a stable release contains docs~, the pre-release docs serve as root
+          root_version="$stable_version"
+          if [ -z "$root_ref" ]; then
+            root_ref="$beta"
+            root_version="$beta"
+            root_channel="beta"
+            beta=""
+          fi
+
+          if [ -z "$root_ref" ]; then
+            echo "No docs source found (no docs-release branch and no docs~ in any tag)" >&2
+            exit 1
+          fi
+
+          {
+            echo "root_ref=$root_ref"
+            echo "root_version=$root_version"
+            echo "root_channel=$root_channel"
+            echo "stable_version=$stable_version"
+            echo "beta=$beta"
+          } >> "$GITHUB_OUTPUT"
+          echo "Deploying root=$root_version from $root_ref ($root_channel), beta=${beta:-none}"
+
+      - name: Build root docs (${{ steps.versions.outputs.root_version }})
+        env:
+          ROOT_REF: ${{ steps.versions.outputs.root_ref }}
+          DOCS_VERSION: ${{ steps.versions.outputs.root_version }}
+          DOCS_CHANNEL: ${{ steps.versions.outputs.root_channel }}
+          DOCS_STABLE_VERSION: ${{ steps.versions.outputs.stable_version }}
+          DOCS_BETA_VERSION: ${{ steps.versions.outputs.beta }}
+        run: |
+          git worktree add "$RUNNER_TEMP/root-src" "$ROOT_REF"
+          cd "$RUNNER_TEMP/root-src/docs~"
+          npm ci
+          npm run docs:build
+          mkdir -p "$GITHUB_WORKSPACE/_site"
+          cp -R .vitepress/dist/. "$GITHUB_WORKSPACE/_site/"
+
+      - name: Build beta docs (${{ steps.versions.outputs.beta }})
+        if: steps.versions.outputs.beta != ''
+        env:
+          DOCS_VERSION: ${{ steps.versions.outputs.beta }}
+          DOCS_CHANNEL: beta
+          DOCS_STABLE_VERSION: ${{ steps.versions.outputs.stable_version }}
+          DOCS_BETA_VERSION: ${{ steps.versions.outputs.beta }}
+        run: |
+          git worktree add "$RUNNER_TEMP/beta-src" "$DOCS_VERSION"
+          cd "$RUNNER_TEMP/beta-src/docs~"
+          npm ci
+          npm run docs:build -- --base "${SITE_BASE}beta/"
+          mkdir -p "$GITHUB_WORKSPACE/_site/beta"
+          cp -R .vitepress/dist/. "$GITHUB_WORKSPACE/_site/beta/"
 
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: docs~/.vitepress/dist
+          path: _site
 
   deploy:
     environment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
       - name: "Checkout"
         uses: "actions/checkout@v4"
 
+      - name: "Remove dev files"
+        run: rm -rf CLAUDE.md CLAUDE.md.meta .gitignore .gitattributes
+
       - name: "Build"
         id: "build"
         uses: "docker://ghcr.io/rerigferl/vpm-packager:latest"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+このファイルはClaude Code (claude.ai/code) がこのリポジトリで作業する際のガイダンスを提供します。
+
+## 言語ルール
+
+- **コーディング**: 英語で行う（コード、コメント、変数名、XMLドキュメント等すべて英語）
+- **作業・会話**: ユーザーとのやり取りや作業説明は日本語で行う
+- **コミットメッセージ**: 英語でConventional Commits形式に従う（例: `feat:`, `fix:`, `docs:`）
+
+## プロジェクト概要
+
+**Kanameliser Editor Plus** — Unity・VRChat向けエディター拡張セット（`net.kanameliser.editor-plus`）。
+
+## リリースパッケージ
+
+GitHub Actionsワークフロー（`.github/workflows/release.yml`）を手動実行すると`vpm-packager`がzip/unitypackageを生成し、draftリリースを作成する。draftを手動でpublishするとリリース完了（beta版はプレリリースとしてpublishする）。
+
+vpm-packagerは`.github/`と`~`末尾ディレクトリのみ自動除外するため、それ以外の開発用ファイル（CLAUDE.md等）はワークフロー内でビルド前に削除している。開発用ファイルを追加した場合は削除リストも更新すること。
+
+## ドキュメントサイト運用
+
+`docs~/`のVitePressサイトをGitHub Pages（https://kxn4t.github.io/kanameliser-editor-plus/）へデプロイする。ワークフローは`.github/workflows/docs.yml`。
+
+### チャンネル構成
+
+| URL | 内容 | ビルドソース |
+| --- | --- | --- |
+| ルート `/` | 安定版ドキュメント | `docs-release`ブランチ |
+| `/beta/` | beta版ドキュメント | 最新のプレリリースタグ（安定版より新しい場合のみ） |
+
+- mainへのマージではサイトは更新されない（未リリース内容は公開されない）
+- デプロイトリガー: リリースpublish / `docs-release`へのpush / 手動実行（workflow_dispatch）
+
+### 通常リリース時（全自動）
+
+リリースをpublishする以外の操作は不要。
+
+- 安定版（`x.y.z`）をpublish → `docs-release`ブランチが自動でタグ位置にforce-updateされ、ルートが更新される。同時にbetaは安定版より新しくなくなるため`/beta/`は消える
+- beta（`x.y.z-beta.N`）をpublish → `/beta/`のみ更新され、ルートは変わらない
+
+### ドキュメントのみの修正（リリース不要）
+
+```bash
+git fetch origin && git checkout docs-release
+git cherry-pick <docs修正コミット>   # または直接編集してコミット
+git push origin docs-release
+```
+
+pushするとルートサイトが自動で再ビルドされる。
+
+**必ずmainにも同じ修正を入れること**（基本はmainにPRで入れてから`docs-release`へcherry-pick）。次の安定版リリースで`docs-release`はタグ位置に上書きされるため、mainにない修正はそこで消える。
+
+`/beta/`側のホットフィックスは非対応。修正は次のbetaリリースに含めて出す。
+
+### バージョン表示の仕組み
+
+- docs.ymlがビルド時に環境変数`DOCS_VERSION` / `DOCS_CHANNEL` / `DOCS_STABLE_VERSION` / `DOCS_BETA_VERSION`を注入する
+- `docs~/.vitepress/config.mts`がナビ右上のバージョンドロップダウン（stable⇔beta相互リンク）を生成し、betaビルドには`noindex`メタタグを付与する
+- betaビルドではページ上部に警告バナーを表示する（`docs~/.vitepress/theme/BetaBanner.vue`）
+- ローカルビルド（環境変数なし）ではバージョン表示・バナーとも表示されない
+
+### 移行期間の注意（1.0.0正式リリースまで）
+
+安定版タグ（0.5.0以前）には`docs~`が存在しないため、`docs-release`ブランチが自動作成される1.0.0のpublishまでは、最新betaタグの内容がルートに配置される（`/beta/`は無し）。

--- a/CLAUDE.md.meta
+++ b/CLAUDE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a51033bb0d3a995d941ee32afa833740
+TextScriptImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/docs~/.vitepress/config.mts
+++ b/docs~/.vitepress/config.mts
@@ -1,4 +1,5 @@
-import { defineConfig } from 'vitepress'
+import { defineConfig, type HeadConfig } from 'vitepress'
+import type { DefaultTheme } from 'vitepress'
 
 const sidebarJa = [
   {
@@ -43,19 +44,53 @@ const sidebarEn = [
 const siteUrl = 'https://kxn4t.github.io/kanameliser-editor-plus'
 const ogImage = `${siteUrl}/og-image.png`
 
+// Version info injected by the docs deployment workflow (.github/workflows/docs.yml).
+// All variables are unset for local dev builds.
+const docsVersion = process.env.DOCS_VERSION
+const docsChannel = process.env.DOCS_CHANNEL
+const stableVersion = process.env.DOCS_STABLE_VERSION
+const betaVersion = process.env.DOCS_BETA_VERSION
+
+const versionMenuItems: DefaultTheme.NavItemWithLink[] = [
+  ...(stableVersion ? [{ text: `v${stableVersion} (stable)`, link: `${siteUrl}/` }] : []),
+  ...(betaVersion ? [{ text: `v${betaVersion} (beta)`, link: `${siteUrl}/beta/` }] : []),
+]
+
+const versionNav: DefaultTheme.NavItem[] = docsVersion
+  ? [
+      versionMenuItems.length > 0
+        ? { text: `v${docsVersion}`, items: versionMenuItems }
+        : { text: `v${docsVersion}`, link: `${siteUrl}/` },
+    ]
+  : []
+
+const head: HeadConfig[] = [
+  ['meta', { property: 'og:type', content: 'website' }],
+  ['meta', { property: 'og:site_name', content: 'Kanameliser Editor Plus' }],
+  ['meta', { property: 'og:image', content: ogImage }],
+  ['meta', { property: 'og:url', content: siteUrl }],
+  ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
+  ['meta', { name: 'twitter:image', content: ogImage }],
+  ['meta', { name: 'twitter:site', content: '@kanameliser' }],
+]
+
+if (docsChannel === 'beta') {
+  // Keep beta docs out of search results
+  head.push(['meta', { name: 'robots', content: 'noindex' }])
+  // Reserve space for the fixed beta banner (BetaBanner.vue); the default
+  // theme offsets nav/sidebar/content by --vp-layout-top-height
+  head.push([
+    'style',
+    {},
+    ':root { --vp-layout-top-height: 32px; } @media (max-width: 560px) { :root { --vp-layout-top-height: 52px; } }',
+  ])
+}
+
 export default defineConfig({
   title: 'Kanameliser Editor Plus',
   base: '/kanameliser-editor-plus/',
 
-  head: [
-    ['meta', { property: 'og:type', content: 'website' }],
-    ['meta', { property: 'og:site_name', content: 'Kanameliser Editor Plus' }],
-    ['meta', { property: 'og:image', content: ogImage }],
-    ['meta', { property: 'og:url', content: siteUrl }],
-    ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
-    ['meta', { name: 'twitter:image', content: ogImage }],
-    ['meta', { name: 'twitter:site', content: '@kanameliser' }],
-  ],
+  head,
 
   locales: {
     root: {
@@ -66,6 +101,7 @@ export default defineConfig({
         nav: [
           { text: 'ドキュメント', link: '/guide/getting-started' },
           { text: '更新履歴', link: '/changelog' },
+          ...versionNav,
         ],
         sidebar: sidebarJa,
         outline: { label: 'このページ' },
@@ -85,6 +121,7 @@ export default defineConfig({
         nav: [
           { text: 'Docs', link: '/en/guide/getting-started' },
           { text: 'Changelog', link: '/en/changelog' },
+          ...versionNav,
         ],
         sidebar: sidebarEn,
       },
@@ -95,5 +132,10 @@ export default defineConfig({
     socialLinks: [
       { icon: 'github', link: 'https://github.com/kxn4t/kanameliser-editor-plus' },
     ],
-  },
+    // Custom key consumed by the theme (BetaBanner.vue)
+    versionBadge: {
+      channel: docsChannel,
+      stableUrl: stableVersion ? `${siteUrl}/` : undefined,
+    },
+  } as DefaultTheme.Config,
 })

--- a/docs~/.vitepress/theme/BetaBanner.vue
+++ b/docs~/.vitepress/theme/BetaBanner.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+import { useData } from 'vitepress'
+
+const { theme, lang } = useData()
+</script>
+
+<template>
+  <div v-if="theme.versionBadge?.channel === 'beta'" class="beta-banner">
+    <span>
+      <template v-if="lang.startsWith('ja')">
+        これはベータ版のドキュメントです。
+        <a v-if="theme.versionBadge.stableUrl" :href="theme.versionBadge.stableUrl"
+          >安定版のドキュメントを見る</a
+        >
+      </template>
+      <template v-else>
+        This documentation is for a beta release.
+        <a v-if="theme.versionBadge.stableUrl" :href="theme.versionBadge.stableUrl"
+          >View the stable documentation</a
+        >
+      </template>
+    </span>
+  </div>
+</template>

--- a/docs~/.vitepress/theme/custom.css
+++ b/docs~/.vitepress/theme/custom.css
@@ -1,4 +1,37 @@
+/* Lift the theme's 392/576px cap so the title renders on one line where it
+   fits, and wrap in balanced lines (natural ja phrase breaks in Chromium)
+   instead of overflowing where it does not */
 .VPHero .name,
 .VPHero .text {
-  white-space: nowrap;
+  max-width: none;
+  text-wrap: balance;
+  word-break: auto-phrase;
 }
+
+/* Fixed banner at the very top; the page is offset via --vp-layout-top-height,
+   which is injected in config.mts only for beta channel builds */
+.beta-banner {
+  position: fixed;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: calc(var(--vp-z-index-nav, 30) + 1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: var(--vp-layout-top-height, 32px);
+  padding: 0 16px;
+  font-size: 13px;
+  line-height: 1.4;
+  text-align: center;
+  /* Opaque warning tint: --vp-c-warning-soft is translucent, so layer it over the bg */
+  background-color: var(--vp-c-bg);
+  background-image: linear-gradient(var(--vp-c-warning-soft), var(--vp-c-warning-soft));
+  color: var(--vp-c-warning-1);
+}
+
+.beta-banner a {
+  font-weight: 500;
+  text-decoration: underline;
+}
+

--- a/docs~/.vitepress/theme/index.ts
+++ b/docs~/.vitepress/theme/index.ts
@@ -1,4 +1,12 @@
+import { h } from 'vue'
 import DefaultTheme from 'vitepress/theme'
+import BetaBanner from './BetaBanner.vue'
 import './custom.css'
 
-export default DefaultTheme
+export default {
+  extends: DefaultTheme,
+  Layout: () =>
+    h(DefaultTheme.Layout, null, {
+      'layout-top': () => h(BetaBanner),
+    }),
+}


### PR DESCRIPTION
## What

ドキュメントサイトを安定版とベータ版の 2 チャンネル構成に分離し、サイト内にバージョン表示を追加しました。

- ルート `/` は安定版（`docs-release` ブランチ）、`/beta/` は最新ベータタグからビルドして 1 つのサイトとしてデプロイ
- ナビ右上にバージョンドロップダウンを追加（stable ⇔ beta 相互リンク）
- ベータビルドにはページ上部の警告バナーと `noindex` メタタグを付与
- 安定版リリースの publish 時に `docs-release` ブランチを自動同期。ドキュメントのみの修正は同ブランチへの push で反映可能
- CLAUDE.md を追加して運用手順を記載し、リリース zip に含まれないよう release.yml に除外ステップを追加
- ついでにヒーロータイトルが狭い画面ではみ出す問題を修正（`max-width` キャップ解除 + バランス折り返し）

## Why

main へのマージやベータリリースの publish で、未リリース機能のドキュメントが本番サイトに載ってしまう問題があったためです。また、リリースを伴わないドキュメント修正（typo 修正など）を反映する手段も必要でした。

## How

- GitHub Pages は 1 リポジトリ 1 サイトのため、デプロイごとに安定版とベータ版の両方をビルドして 1 つの成果物に合成する方式を採用
- ルートのビルドソースはタグ直参照ではなく `docs-release` ブランチ参照とし、リリースなしのドキュメント修正を可能にした（タグ直参照案は docs 修正のたびにリリースが必要になるため不採用）
- ベータ側は最新のプレリリースタグから `--base` を上書きしてビルドし、安定版より新しいベータが存在する場合のみデプロイ
- バージョン情報はワークフローから環境変数（`DOCS_VERSION` / `DOCS_CHANNEL` / `DOCS_STABLE_VERSION` / `DOCS_BETA_VERSION`）で注入し、config.mts がナビとバナー用の設定を生成
- バナーは `layout-top` スロット + `--vp-layout-top-height` による固定表示（デフォルトテーマがナビ・サイドバー・コンテンツを自動オフセットする公式パターン）
- 安定版タグに `docs~` が存在しない移行期間（1.0.0 リリースまで）はベータタグの内容をルートに配置

## 動作確認

- ローカルで安定版・ベータ版・環境変数なしの 3 パターンをビルドし、以下を確認
  - 安定版: バージョンドロップダウンあり、バナー・noindex なし
  - ベータ版: `/beta/` ベースのアセットパス、バナー・noindex・バージョン表示あり（日英両ロケール）
  - 環境変数なし（ローカル dev）: バージョン表示なしで通常どおりビルド成功
- 2 つのビルドを本番と同じ構成に合成してローカルサーバーで配信し、バナー表示・バージョンドロップダウン・レスポンシブ挙動（バナーとナビの重なりなし、タイトル折り返し）を実際の画面で確認
- タグ解決ロジックを実リポジトリのタグでドライラン（安定版タグなし → ベータフォールバック、ベータ採否判定の 3 ケース）
