### PR TITLE
fix: improve readability of performance tip in color menu guide

### DIFF
--- a/Editor/Localization/en-us.po
+++ b/Editor/Localization/en-us.po
@@ -52,11 +52,29 @@ msgstr "Copied from '{0}' ({1} objects, {2} materials).\nNow select the outfit a
 msgid "maMaterialHelper.guide.perfTitle"
 msgstr "Performance tip"
 
-msgid "maMaterialHelper.guide.perfNote"
-msgstr "Currently, meshes targeted by color change menus and toggles are excluded from automatic mesh merging by AAO: Avatar Optimizer's Trace and Optimize, so they cost extra draw calls.\nOnce your menus are built, merge the meshes with these steps to reduce the load while keeping everything working:\n1. Select the always-visible meshes → right-click → 'Create Merge Skinned Mesh (Exclude Object Toggle)'\n2. Right-click each object with an MA Object Toggle → 'Create Merge Skinned Mesh (From Object Toggle)'\nThe created Merge Skinned Mesh objects can be renamed and moved within the avatar.\nNote: when you change color menus or toggles afterwards, delete the created Merge Skinned Mesh objects and run the commands again."
+msgid "maMaterialHelper.guide.perfNote.intro"
+msgstr "Currently, meshes targeted by color change menus and toggles are excluded from automatic mesh merging by AAO: Avatar Optimizer's Trace and Optimize, so they cost extra draw calls."
 
-msgid "maMaterialHelper.guide.perfNoteNoAao"
-msgstr "Currently, meshes targeted by a color change menu are excluded from automatic mesh merging by AAO: Avatar Optimizer's Trace and Optimize, so they stay separate and cost extra draw calls.\nWhen AAO is installed, 'Create Merge Skinned Mesh (Color Menu Safe)' appears in the right-click menu to merge them without breaking the color menu."
+msgid "maMaterialHelper.guide.perfNote.lead"
+msgstr "Once your menus are built, merge the meshes with these steps to reduce the load while keeping everything working:"
+
+msgid "maMaterialHelper.guide.perfNote.step1"
+msgstr "Select the always-visible meshes → right-click → 'Create Merge Skinned Mesh (Exclude Object Toggle)'"
+
+msgid "maMaterialHelper.guide.perfNote.step2"
+msgstr "Right-click each object with an MA Object Toggle → 'Create Merge Skinned Mesh (From Object Toggle)'"
+
+msgid "maMaterialHelper.guide.perfNote.rename"
+msgstr "The created Merge Skinned Mesh objects can be renamed and moved within the avatar."
+
+msgid "maMaterialHelper.guide.perfNote.caution"
+msgstr "Note: when you change color menus or toggles afterwards, delete the created Merge Skinned Mesh objects and run the commands again."
+
+msgid "maMaterialHelper.guide.perfNoteNoAao.intro"
+msgstr "Currently, meshes targeted by a color change menu are excluded from automatic mesh merging by AAO: Avatar Optimizer's Trace and Optimize, so they stay separate and cost extra draw calls."
+
+msgid "maMaterialHelper.guide.perfNoteNoAao.suggest"
+msgstr "When AAO is installed, 'Create Merge Skinned Mesh (Color Menu Safe)' appears in the right-click menu to merge them without breaking the color menu."
 
 msgid "maMaterialHelper.noSetupGroups"
 msgstr "No material setup groups found"

--- a/Editor/Localization/ja-jp.po
+++ b/Editor/Localization/ja-jp.po
@@ -52,11 +52,29 @@ msgstr "「{0}」からコピー済み（{1}オブジェクト・{2}マテリア
 msgid "maMaterialHelper.guide.perfTitle"
 msgstr "パフォーマンスのヒント"
 
-msgid "maMaterialHelper.guide.perfNote"
-msgstr "現状、色変更メニューやトグルの対象メッシュは、AAO: Avatar OptimizerのTrace and Optimizeによる自動メッシュ統合の対象外になるため、ドローコールなどの負荷が増えがちです。\nメニュー類を作り終えたら、次の手順でメッシュを統合すると、動作を保ったまま負荷を抑えられます。\n1. 常時表示のメッシュをまとめて選択 → 右クリック →「Create Merge Skinned Mesh (Exclude Object Toggle)」\n2. MA Object Toggleが付いた各オブジェクトを右クリック →「Create Merge Skinned Mesh (From Object Toggle)」\n作成されたMerge Skinned Meshオブジェクトは、名前の変更やアバター内での移動も可能です。\n※色変更やトグルを変更した場合は、作成したMerge Skinned Meshを削除してコマンドを再実行してください。"
+msgid "maMaterialHelper.guide.perfNote.intro"
+msgstr "現状、色変更メニューやトグルの対象メッシュは、AAO: Avatar OptimizerのTrace and Optimizeによる自動メッシュ統合の対象外になるため、ドローコールなどの負荷が増えがちです。"
 
-msgid "maMaterialHelper.guide.perfNoteNoAao"
-msgstr "現状、色変更メニューの対象メッシュは、AAO: Avatar OptimizerのTrace and Optimizeによる自動メッシュ統合の対象外になるため、メッシュが統合されずドローコールなどの負荷が増えがちです。\nAAO導入時は右クリックメニューに「Create Merge Skinned Mesh (Color Menu Safe)」が表示され、色変更を壊さずにメッシュを統合できます。"
+msgid "maMaterialHelper.guide.perfNote.lead"
+msgstr "メニュー類を作り終えたら、次の手順でメッシュを統合すると、動作を保ったまま負荷を抑えられます。"
+
+msgid "maMaterialHelper.guide.perfNote.step1"
+msgstr "常時表示のメッシュをまとめて選択 → 右クリック →「Create Merge Skinned Mesh (Exclude Object Toggle)」"
+
+msgid "maMaterialHelper.guide.perfNote.step2"
+msgstr "MA Object Toggleが付いた各オブジェクトを右クリック →「Create Merge Skinned Mesh (From Object Toggle)」"
+
+msgid "maMaterialHelper.guide.perfNote.rename"
+msgstr "作成されたMerge Skinned Meshオブジェクトは、名前の変更やアバター内での移動も可能です。"
+
+msgid "maMaterialHelper.guide.perfNote.caution"
+msgstr "※色変更やトグルを変更した場合は、作成したMerge Skinned Meshを削除してコマンドを再実行してください。"
+
+msgid "maMaterialHelper.guide.perfNoteNoAao.intro"
+msgstr "現状、色変更メニューの対象メッシュは、AAO: Avatar OptimizerのTrace and Optimizeによる自動メッシュ統合の対象外になるため、メッシュが統合されずドローコールなどの負荷が増えがちです。"
+
+msgid "maMaterialHelper.guide.perfNoteNoAao.suggest"
+msgstr "AAO導入時は右クリックメニューに「Create Merge Skinned Mesh (Color Menu Safe)」が表示され、色変更を壊さずにメッシュを統合できます。"
 
 msgid "maMaterialHelper.noSetupGroups"
 msgstr "マテリアルセットアップのグループが見つかりませんでした"

--- a/Editor/MAMaterialHelper/ColorMenuGuideWindow.cs
+++ b/Editor/MAMaterialHelper/ColorMenuGuideWindow.cs
@@ -27,7 +27,7 @@ namespace Kanameliser.Editor.MAMaterialHelper
         {
             var window = GetWindow<ColorMenuGuideWindow>();
             window.titleContent = new GUIContent("How to Create Color Menu");
-            window.minSize = new Vector2(380, 490);
+            window.minSize = new Vector2(380, 530);
         }
 
         public void CreateGUI()
@@ -89,17 +89,49 @@ namespace Kanameliser.Editor.MAMaterialHelper
             title.AddToClassList("ndmf-tr");
             card.Add(title);
 
-            // The merge command only exists when AAO is installed, so guide to it accordingly
+            // The merge commands only exist when AAO is installed, so guide to them accordingly
 #if AVATAR_OPTIMIZER_INSTALLED
-            var text = new Label("maMaterialHelper.guide.perfNote");
+            card.Add(CreatePerfParagraph("maMaterialHelper.guide.perfNote.intro"));
+            card.Add(CreatePerfParagraph("maMaterialHelper.guide.perfNote.lead"));
+
+            var stepList = new VisualElement();
+            stepList.AddToClassList("perf-step-list");
+            stepList.Add(CreatePerfStep("1.", "maMaterialHelper.guide.perfNote.step1"));
+            stepList.Add(CreatePerfStep("2.", "maMaterialHelper.guide.perfNote.step2"));
+            card.Add(stepList);
+
+            card.Add(CreatePerfParagraph("maMaterialHelper.guide.perfNote.rename"));
+            var caution = CreatePerfParagraph("maMaterialHelper.guide.perfNote.caution");
+            caution.AddToClassList("perf-caution");
+            card.Add(caution);
 #else
-            var text = new Label("maMaterialHelper.guide.perfNoteNoAao");
+            card.Add(CreatePerfParagraph("maMaterialHelper.guide.perfNoteNoAao.intro"));
+            card.Add(CreatePerfParagraph("maMaterialHelper.guide.perfNoteNoAao.suggest"));
 #endif
-            text.AddToClassList("perf-text");
-            text.AddToClassList("ndmf-tr");
-            card.Add(text);
 
             return card;
+        }
+
+        private static Label CreatePerfParagraph(string textKey)
+        {
+            var text = new Label(textKey);
+            text.AddToClassList("perf-text");
+            text.AddToClassList("ndmf-tr");
+            return text;
+        }
+
+        private static VisualElement CreatePerfStep(string number, string textKey)
+        {
+            var row = new VisualElement();
+            row.AddToClassList("perf-step");
+
+            var num = new Label(number);
+            num.AddToClassList("perf-step-number");
+            row.Add(num);
+
+            row.Add(CreatePerfParagraph(textKey));
+
+            return row;
         }
 
         private static VisualElement CreateStepCard(string number, string textKey)

--- a/Editor/MAMaterialHelper/ColorMenuGuideWindow.uss
+++ b/Editor/MAMaterialHelper/ColorMenuGuideWindow.uss
@@ -102,9 +102,38 @@
 
 .perf-title {
     -unity-font-style: bold;
-    margin-bottom: 4px;
+    margin-bottom: 2px;
 }
 
 .perf-text {
     white-space: normal;
+    margin-top: 4px;
+}
+
+.perf-step-list {
+    margin-top: 4px;
+    margin-bottom: 4px;
+}
+
+.perf-step {
+    flex-direction: row;
+    margin-top: 4px;
+    margin-left: 4px;
+}
+
+.perf-step .perf-text {
+    flex-grow: 1;
+    flex-shrink: 1;
+    margin-top: 0;
+}
+
+.perf-step-number {
+    flex-shrink: 0;
+    margin-right: 3px;
+    -unity-font-style: bold;
+}
+
+.perf-caution {
+    margin-top: 6px;
+    opacity: 0.75;
 }


### PR DESCRIPTION
## What
色変更メニューガイドウィンドウの「パフォーマンスのヒント」を段落構造に分割し、読みやすくしました。

- ローカライズ文字列を段落ごとのキーに分割（表示される文言自体は変更なし）
- 段落間に余白を追加し、手順 1・2 は番号付きリスト表示に
- 手順リストの上下はリスト内より広めの余白にして、リストのまとまりを明確化
- 末尾の「※〜」注意書きを減光表示（`opacity: 0.75`）で本文と区別
- 余白増加分として、ウィンドウ最小高さを 490 → 530 に変更

## Why
ヒント全文が 1 つの Label に `\n` 区切りで詰め込まれており、行間・段落間の余白がなく読みづらかったため。

## How
- UI Toolkit の USS には `line-height` や隣接セレクター（`+`）がないため、段落ごとに Label を分けて margin で余白を付ける構造にした
- NDMF ローカライズ（`ndmf-tr`）は Label 単位でキーを解決するため、ローカライズキーの分割が必要
- 手順リストは番号 Label ＋本文 Label の行レイアウトにし、折り返し時も本文が番号の右に揃うぶら下げインデントにした