### PR TITLE
docs: add per-page og:title, og:description, and og:url meta tags

### DIFF
--- a/docs~/.vitepress/config.mts
+++ b/docs~/.vitepress/config.mts
@@ -41,8 +41,11 @@ const sidebarEn = [
   },
 ]
 
+const siteTitle = 'Kanameliser Editor Plus'
 const siteUrl = 'https://kxn4t.github.io/kanameliser-editor-plus'
 const ogImage = `${siteUrl}/og-image.png`
+const descriptionJa = 'Unity・VRChat向けエディター拡張セット'
+const descriptionEn = 'A set of useful editor extensions for Unity and VRChat'
 
 // Version info injected by the docs deployment workflow (.github/workflows/docs.yml).
 // All variables are unset for local dev builds.
@@ -66,13 +69,17 @@ const versionNav: DefaultTheme.NavItem[] = docsVersion
 
 const head: HeadConfig[] = [
   ['meta', { property: 'og:type', content: 'website' }],
-  ['meta', { property: 'og:site_name', content: 'Kanameliser Editor Plus' }],
+  ['meta', { property: 'og:site_name', content: siteTitle }],
   ['meta', { property: 'og:image', content: ogImage }],
-  ['meta', { property: 'og:url', content: siteUrl }],
   ['meta', { name: 'twitter:card', content: 'summary_large_image' }],
   ['meta', { name: 'twitter:image', content: ogImage }],
   ['meta', { name: 'twitter:site', content: '@kanameliser' }],
 ]
+
+// Per-page OG tags. X (Twitter) requires og:title/twitter:title to render a
+// card at all — it does not fall back to the <title> tag — and VitePress only
+// emits <title>/description on its own, so inject them per page here.
+const pageUrlBase = docsChannel === 'beta' ? `${siteUrl}/beta` : siteUrl
 
 if (docsChannel === 'beta') {
   // Keep beta docs out of search results
@@ -87,18 +94,34 @@ if (docsChannel === 'beta') {
 }
 
 export default defineConfig({
-  title: 'Kanameliser Editor Plus',
+  title: siteTitle,
   base: '/kanameliser-editor-plus/',
   // GitHub Pages serves /foo from foo.html natively, so no host config is needed
   cleanUrls: true,
 
   head,
 
+  transformPageData(pageData) {
+    const title = pageData.title ? `${pageData.title} | ${siteTitle}` : siteTitle
+    const description =
+      pageData.description ||
+      (pageData.relativePath.startsWith('en/') ? descriptionEn : descriptionJa)
+    const pagePath = pageData.relativePath
+      .replace(/(^|\/)index\.md$/, '$1')
+      .replace(/\.md$/, '')
+    const pageHead = (pageData.frontmatter.head ??= [])
+    pageHead.push(
+      ['meta', { property: 'og:title', content: title }],
+      ['meta', { property: 'og:description', content: description }],
+      ['meta', { property: 'og:url', content: `${pageUrlBase}/${pagePath}` }],
+    )
+  },
+
   locales: {
     root: {
       label: '日本語',
       lang: 'ja',
-      description: 'Unity・VRChat向けエディター拡張セット',
+      description: descriptionJa,
       themeConfig: {
         nav: [
           { text: 'ドキュメント', link: '/guide/getting-started' },
@@ -118,7 +141,7 @@ export default defineConfig({
     en: {
       label: 'English',
       lang: 'en',
-      description: 'A set of useful editor extensions for Unity and VRChat',
+      description: descriptionEn,
       themeConfig: {
         nav: [
           { text: 'Docs', link: '/en/guide/getting-started' },


### PR DESCRIPTION
## What
X（Twitter）でドキュメントサイトのリンクカードが展開されない問題を修正するため、全ページにページごとの OGP メタタグを追加します。

- `transformPageData` フックで `og:title` / `og:description` / `og:url` をページごとに注入
- 全ページ共通でサイトトップを指していたグローバルの `og:url` を削除
- サイトタイトルと言語別説明文を定数化し、`locales` 設定と共用

## Why
`og:image` と `twitter:card` は設定済みでしたが、X はカード描画に `twitter:title`（または `og:title`）を必須とし、HTML の `<title>` タグにはフォールバックしません。そのためカード自体が描画されず、画像が展開されない状態でした。Discord や Slack は `<title>` を拾うため、X でのみ発生していました。

## How
- VitePress は `<title>` と `description` メタは自動生成するものの OGP 用タグは出力しないため、`transformPageData` でフロントマターの `head` に追記する方式を採用
- `og:description` はフロントマターの `description` があればそれを、なければ `relativePath` の `en/` プレフィックスで判定した言語別のサイト説明文を使用
- beta ビルドは `--base` で `/beta/` 配下に配置されるため、`og:url` は `DOCS_CHANNEL` 環境変数で分岐

ローカルビルドで、トップ・機能ページ・en ページそれぞれに正しいタイトル・説明文・URL が出力されることを確認済みです。反映には本修正を含むタグの publish が必要です（移行期間中はルートサイトが最新 beta タグからビルドされるため）。