### PR TITLE
docs: link the documentation site from README and CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Documentation site** — Launched the official documentation site at [https://kxn4t.github.io/kanameliser-editor-plus/](https://kxn4t.github.io/kanameliser-editor-plus/) (available in Japanese and English). It provides getting-started and per-feature guides; explanations and screenshots are still being expanded.
+
+---
+
+### 追加
+
+- **ドキュメントサイト** — 公式ドキュメントサイト [https://kxn4t.github.io/kanameliser-editor-plus/](https://kxn4t.github.io/kanameliser-editor-plus/) を公開しました（日本語・英語対応）。導入手順と各機能の使い方を掲載しています。説明やスクリーンショットは今後も拡充していく予定です。
+
 ## [1.0.0-beta.2] - 2026-08-08
 
 ### Added

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,8 @@
 
 UnityおよびVRChatのための便利なエディター拡張機能セット。
 
+**ドキュメント**: [https://kxn4t.github.io/kanameliser-editor-plus/](https://kxn4t.github.io/kanameliser-editor-plus/)
+
 ## インストール方法
 
 ### VRChat Creator Companion経由（推奨）

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A set of useful editor extensions for Unity and VRChat.
 
+**Documentation**: [https://kxn4t.github.io/kanameliser-editor-plus/en/](https://kxn4t.github.io/kanameliser-editor-plus/en/)
+
 ## Installation
 
 ### Via VRChat Creator Companion (Recommended)


### PR DESCRIPTION
## What
公開済みのドキュメントサイトへの導線を README と CHANGELOG に追加します。

- `README.md` / `README.ja.md` の冒頭にドキュメントサイトへのリンクを追加（英語版は `/en/`、日本語版はルートへ）
- `CHANGELOG.md` の `[Unreleased]` にドキュメントサイト公開のエントリを英日併記で追加

## Why
ドキュメントサイトはすでに公開されているものの、リポジトリ側からの導線やリリースノートでの告知がなかったため。

## How
- CHANGELOG のエントリには、説明やスクリーンショットが今後も拡充予定である旨を明記
- README は冒頭のタグライン直後にテキストリンク 1 行のみのシンプルな形