### PR TITLE
feat: show particle system info in Mesh Info display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Mesh Info Display: Particle system info** — When the selection contains particle systems or Trail/Line renderers, the Mesh Info display now shows a separate section below the mesh counts: `Particle Systems` (component count), `Particle Slots` (material slots used by particle systems; trails use a second slot), and `Trail/Line Slots` (material slots used by Trail/Line renderers). These renderers consume Material Slots in VRChat's avatar performance rank separately from Mesh/Skinned Mesh Renderers, so they are shown apart from the mesh-based counts, which keep their meaning; the rank's actual Material Slots value is the sum of `Material Slots` and the new slot counts. The section can be toggled via `Tools > Kanameliser Editor Plus > [Settings] > Show Particle Info Display`.
 - **Documentation site** — Launched the official documentation site at [https://kxn4t.github.io/kanameliser-editor-plus/](https://kxn4t.github.io/kanameliser-editor-plus/) (available in Japanese and English). It provides getting-started and per-feature guides; explanations and screenshots are still being expanded.
 
 ---
 
 ### 追加
 
+- **Mesh Info Display: パーティクルシステム情報** — 選択中のオブジェクトにパーティクルシステムや Trail/Line レンダラーが含まれる場合、メッシュ情報の下に別セクションとして `Particle Systems`（コンポーネント数）、`Particle Slots`（パーティクルが消費するマテリアルスロット数。Trails 有効時は 2 スロット）、`Trail/Line Slots`（Trail/Line レンダラーが消費するマテリアルスロット数）を表示するようになりました。これらは Mesh/Skinned Mesh Renderer とは別枠で VRChat のパフォーマンスランクの Material Slots を消費するため、既存のメッシュ系カウントの意味は変えずに分けて表示します（ランク上の実際の Material Slots は既存の `Material Slots` と追加スロットの合計です）。表示は `Tools > Kanameliser Editor Plus > [Settings] > Show Particle Info Display` でオンオフできます。
 - **ドキュメントサイト** — 公式ドキュメントサイト [https://kxn4t.github.io/kanameliser-editor-plus/](https://kxn4t.github.io/kanameliser-editor-plus/) を公開しました（日本語・英語対応）。導入手順と各機能の使い方を掲載しています。説明やスクリーンショットは今後も拡充していく予定です。
 
 ## [1.0.0-beta.2] - 2026-08-08

--- a/Editor/MeshInfo/MeshInfoCalculator.cs
+++ b/Editor/MeshInfo/MeshInfoCalculator.cs
@@ -16,7 +16,7 @@ namespace Kanameliser.EditorPlus
 
             foreach (var obj in gameObjects)
             {
-                data.Triangles += ProcessGameObject(obj, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref materialSlots);
+                data.Triangles += ProcessGameObject(obj, data, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref materialSlots);
             }
 
             data.Meshes = processedMeshes.Count;
@@ -27,7 +27,7 @@ namespace Kanameliser.EditorPlus
             return data;
         }
 
-        private int ProcessGameObject(GameObject obj, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials, HashSet<Renderer> processedRenderers,
+        private int ProcessGameObject(GameObject obj, MeshInfoData data, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials, HashSet<Renderer> processedRenderers,
             ref bool hasChildObjects, ref int totalMaterialSlots)
         {
             // Skip objects tagged as EditorOnly as they won't be included in builds
@@ -41,10 +41,11 @@ namespace Kanameliser.EditorPlus
             int triangleCount = 0;
 
             triangleCount += MeshInfoUtility.ProcessStandardMeshComponents(obj, processedMeshes, processedMaterials, processedRenderers, ref totalMaterialSlots);
+            MeshInfoUtility.ProcessParticleComponents(obj, data);
 
             foreach (Transform child in obj.transform)
             {
-                triangleCount += ProcessGameObject(child.gameObject, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref totalMaterialSlots);
+                triangleCount += ProcessGameObject(child.gameObject, data, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref totalMaterialSlots);
             }
 
             return triangleCount;

--- a/Editor/MeshInfo/MeshInfoConstants.cs
+++ b/Editor/MeshInfo/MeshInfoConstants.cs
@@ -6,6 +6,8 @@ namespace Kanameliser.EditorPlus
     {
         public const string MenuPath = "Tools/Kanameliser Editor Plus/[Settings]/Show Mesh Info Display";
         public const string PreferenceKey = "MeshInfoDisplayVisible";
+        public const string ParticleInfoMenuPath = "Tools/Kanameliser Editor Plus/[Settings]/Show Particle Info Display";
+        public const string ParticleInfoPreferenceKey = "MeshInfoParticleInfoVisible";
 
         public const int WindowWidth = 170;
         public const int WindowHeight = 95;
@@ -26,6 +28,10 @@ namespace Kanameliser.EditorPlus
         public const int TitleSpacing = 20;
         public const int WarningSpacing = 5;
 
+        public const int InfoLineHeight = 16;
+        public const int SeparatorHeight = 1;
+        public const int SeparatorSpacing = 4;
+
         public const double UpdateIntervalSeconds = 0.2;
 
         public static readonly Color BackgroundColor = new Color(0.2f, 0.2f, 0.2f, 0.3f);
@@ -33,5 +39,6 @@ namespace Kanameliser.EditorPlus
         public static readonly Color DiffDecreaseBackgroundColor = new Color(0.2f, 0.8f, 0.2f, 0.6f);
         public static readonly Color PreviewDotColor = new Color(0.3f, 1f, 0.3f, 1f);
         public static readonly Color WarningTextColor = new Color(1f, 1f, 0.5f);
+        public static readonly Color SeparatorColor = new Color(1f, 1f, 1f, 0.25f);
     }
 }

--- a/Editor/MeshInfo/MeshInfoData.cs
+++ b/Editor/MeshInfo/MeshInfoData.cs
@@ -6,6 +6,9 @@ namespace Kanameliser.EditorPlus
         public int Materials { get; set; }
         public int Meshes { get; set; }
         public int MaterialSlots { get; set; }
+        public int ParticleSystems { get; set; }
+        public int ParticleMaterialSlots { get; set; }
+        public int TrailLineMaterialSlots { get; set; }
         public bool HasChildObjects { get; set; }
 
         public void Reset()
@@ -14,6 +17,9 @@ namespace Kanameliser.EditorPlus
             Materials = 0;
             Meshes = 0;
             MaterialSlots = 0;
+            ParticleSystems = 0;
+            ParticleMaterialSlots = 0;
+            TrailLineMaterialSlots = 0;
             HasChildObjects = false;
         }
 
@@ -25,6 +31,9 @@ namespace Kanameliser.EditorPlus
                 Materials = Materials,
                 Meshes = Meshes,
                 MaterialSlots = MaterialSlots,
+                ParticleSystems = ParticleSystems,
+                ParticleMaterialSlots = ParticleMaterialSlots,
+                TrailLineMaterialSlots = TrailLineMaterialSlots,
                 HasChildObjects = HasChildObjects
             };
         }

--- a/Editor/MeshInfo/MeshInfoDisplay.cs
+++ b/Editor/MeshInfo/MeshInfoDisplay.cs
@@ -8,6 +8,7 @@ namespace Kanameliser.EditorPlus
     internal class MeshInfoDisplay
     {
         private static bool isDisplayVisible;
+        private static bool isParticleInfoVisible;
         private static GameObject[] previousSelection;
         private static readonly MeshInfoCalculator calculator = new MeshInfoCalculator();
         private static readonly MeshInfoRenderer renderer = new MeshInfoRenderer();
@@ -26,6 +27,8 @@ namespace Kanameliser.EditorPlus
         {
             isDisplayVisible = EditorPrefs.GetBool(MeshInfoConstants.PreferenceKey, true);
             Menu.SetChecked(MeshInfoConstants.MenuPath, isDisplayVisible);
+            isParticleInfoVisible = EditorPrefs.GetBool(MeshInfoConstants.ParticleInfoPreferenceKey, true);
+            Menu.SetChecked(MeshInfoConstants.ParticleInfoMenuPath, isParticleInfoVisible);
             forceUpdate = true;
             lastUpdateTime = 0;
             SceneView.duringSceneGui += OnSceneGUI;
@@ -38,6 +41,19 @@ namespace Kanameliser.EditorPlus
             isDisplayVisible = !isDisplayVisible;
             EditorPrefs.SetBool(MeshInfoConstants.PreferenceKey, isDisplayVisible);
             Menu.SetChecked(MeshInfoConstants.MenuPath, isDisplayVisible);
+
+            if (SceneView.lastActiveSceneView != null)
+                SceneView.lastActiveSceneView.Repaint();
+            else
+                SceneView.RepaintAll();
+        }
+
+        [MenuItem(MeshInfoConstants.ParticleInfoMenuPath)]
+        private static void ToggleParticleInfoVisibility()
+        {
+            isParticleInfoVisible = !isParticleInfoVisible;
+            EditorPrefs.SetBool(MeshInfoConstants.ParticleInfoPreferenceKey, isParticleInfoVisible);
+            Menu.SetChecked(MeshInfoConstants.ParticleInfoMenuPath, isParticleInfoVisible);
 
             if (SceneView.lastActiveSceneView != null)
                 SceneView.lastActiveSceneView.Repaint();
@@ -102,9 +118,9 @@ namespace Kanameliser.EditorPlus
         {
 #if NDMF_INSTALLED
             renderer.DrawMeshInfo(currentData, originalData,
-                ndmfIntegration.IsShowingProxyInfo, ndmfIntegration.HasProxyInSelection);
+                ndmfIntegration.IsShowingProxyInfo, ndmfIntegration.HasProxyInSelection, isParticleInfoVisible);
 #else
-            renderer.DrawMeshInfo(currentData);
+            renderer.DrawMeshInfo(currentData, showParticleInfo: isParticleInfoVisible);
 #endif
         }
 

--- a/Editor/MeshInfo/MeshInfoNDMFIntegration.cs
+++ b/Editor/MeshInfo/MeshInfoNDMFIntegration.cs
@@ -43,7 +43,7 @@ namespace Kanameliser.EditorPlus
 
             foreach (var obj in gameObjects)
             {
-                data.Triangles += ProcessGameObjectWithProxy(obj, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref materialSlots);
+                data.Triangles += ProcessGameObjectWithProxy(obj, data, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref materialSlots);
             }
 
             data.Meshes = processedMeshes.Count;
@@ -54,7 +54,7 @@ namespace Kanameliser.EditorPlus
             return data;
         }
 
-        private int ProcessGameObjectWithProxy(GameObject obj, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials, HashSet<Renderer> processedRenderers,
+        private int ProcessGameObjectWithProxy(GameObject obj, MeshInfoData data, HashSet<Mesh> processedMeshes, HashSet<Material> processedMaterials, HashSet<Renderer> processedRenderers,
             ref bool hasChildObjects, ref int totalMaterialSlots)
         {
             if (obj.CompareTag("EditorOnly"))
@@ -62,6 +62,9 @@ namespace Kanameliser.EditorPlus
 
             if (!hasChildObjects && obj.transform.childCount > 0)
                 hasChildObjects = true;
+
+            // Particle components are never proxied by NDMF, so always count them on the original object
+            MeshInfoUtility.ProcessParticleComponents(obj, data);
 
             int triangleCount = 0;
             var renderer = obj.GetComponent<Renderer>();
@@ -78,7 +81,7 @@ namespace Kanameliser.EditorPlus
 
                     foreach (Transform child in obj.transform)
                     {
-                        triangleCount += ProcessGameObjectWithProxy(child.gameObject, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref totalMaterialSlots);
+                        triangleCount += ProcessGameObjectWithProxy(child.gameObject, data, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref totalMaterialSlots);
                     }
 
                     return triangleCount;
@@ -89,7 +92,7 @@ namespace Kanameliser.EditorPlus
 
             foreach (Transform child in obj.transform)
             {
-                triangleCount += ProcessGameObjectWithProxy(child.gameObject, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref totalMaterialSlots);
+                triangleCount += ProcessGameObjectWithProxy(child.gameObject, data, processedMeshes, processedMaterials, processedRenderers, ref hasChildObjects, ref totalMaterialSlots);
             }
 
             return triangleCount;

--- a/Editor/MeshInfo/MeshInfoRenderer.cs
+++ b/Editor/MeshInfo/MeshInfoRenderer.cs
@@ -71,13 +71,25 @@ namespace Kanameliser.EditorPlus
         }
 
         public void DrawMeshInfo(MeshInfoData currentData, MeshInfoData originalData = null,
-            bool isShowingProxyInfo = false, bool hasProxyInSelection = false)
+            bool isShowingProxyInfo = false, bool hasProxyInSelection = false, bool showParticleInfo = true)
         {
             Handles.BeginGUI();
             EnsureStylesInitialized();
 
+            GetParticleLineVisibility(currentData, originalData, showParticleInfo,
+                out bool showParticleSystems, out bool showParticleSlots, out bool showTrailLineSlots);
+            int particleLineCount = (showParticleSystems ? 1 : 0) + (showParticleSlots ? 1 : 0) + (showTrailLineSlots ? 1 : 0);
+
+            // Extend the window below the base layout when the particle section is visible
+            float windowHeight = MeshInfoConstants.WindowHeight;
+            if (particleLineCount > 0)
+            {
+                windowHeight += MeshInfoConstants.SeparatorSpacing * 2 + MeshInfoConstants.SeparatorHeight
+                    + particleLineCount * MeshInfoConstants.InfoLineHeight;
+            }
+
             var windowRect = new Rect(MeshInfoConstants.WindowPositionX, MeshInfoConstants.WindowPositionY,
-                MeshInfoConstants.WindowWidth, MeshInfoConstants.WindowHeight);
+                MeshInfoConstants.WindowWidth, windowHeight);
 
             // Draw background
             GUI.DrawTexture(windowRect, backgroundTexture);
@@ -106,6 +118,32 @@ namespace Kanameliser.EditorPlus
 #endif
             {
                 DrawStaticLabels(currentData);
+            }
+
+            if (particleLineCount > 0)
+            {
+                DrawSeparator();
+#if NDMF_INSTALLED
+                if (originalData != null)
+                {
+                    bool showDiff = isShowingProxyInfo && hasProxyInSelection;
+                    if (showParticleSystems)
+                        DrawDynamicLabel("Particle Systems", originalData.ParticleSystems, currentData.ParticleSystems, showDiff);
+                    if (showParticleSlots)
+                        DrawDynamicLabel("Particle Slots", originalData.ParticleMaterialSlots, currentData.ParticleMaterialSlots, showDiff);
+                    if (showTrailLineSlots)
+                        DrawDynamicLabel("Trail/Line Slots", originalData.TrailLineMaterialSlots, currentData.TrailLineMaterialSlots, showDiff);
+                }
+                else
+#endif
+                {
+                    if (showParticleSystems)
+                        GUILayout.Label($"Particle Systems: {currentData.ParticleSystems}", infoStyle);
+                    if (showParticleSlots)
+                        GUILayout.Label($"Particle Slots: {currentData.ParticleMaterialSlots}", infoStyle);
+                    if (showTrailLineSlots)
+                        GUILayout.Label($"Trail/Line Slots: {currentData.TrailLineMaterialSlots}", infoStyle);
+                }
             }
 
 #if NDMF_INSTALLED
@@ -139,6 +177,38 @@ namespace Kanameliser.EditorPlus
             GUILayout.Label($"Materials: {data.Materials}", infoStyle);
             GUILayout.Label($"Material Slots: {data.MaterialSlots}", infoStyle);
             GUILayout.Label($"Meshes: {data.Meshes}", infoStyle);
+        }
+
+        private static void GetParticleLineVisibility(MeshInfoData current, MeshInfoData original, bool showParticleInfo,
+            out bool showParticleSystems, out bool showParticleSlots, out bool showTrailLineSlots)
+        {
+            showParticleSystems = false;
+            showParticleSlots = false;
+            showTrailLineSlots = false;
+
+            if (!showParticleInfo)
+                return;
+
+            // Compare against both current and original data so removals (e.g. by NDMF plugins) stay visible as diffs
+            int particleSystems = Mathf.Max(current.ParticleSystems, original != null ? original.ParticleSystems : 0);
+            int trailLineSlots = Mathf.Max(current.TrailLineMaterialSlots, original != null ? original.TrailLineMaterialSlots : 0);
+
+            showParticleSystems = particleSystems > 0;
+            showParticleSlots = particleSystems > 0;
+            showTrailLineSlots = trailLineSlots > 0;
+        }
+
+        private void DrawSeparator()
+        {
+            GUILayout.Space(MeshInfoConstants.SeparatorSpacing);
+
+            var separatorRect = GUILayoutUtility.GetRect(1f, MeshInfoConstants.SeparatorHeight, GUILayout.ExpandWidth(true));
+            Color originalColor = GUI.color;
+            GUI.color = MeshInfoConstants.SeparatorColor;
+            GUI.DrawTexture(separatorRect, Texture2D.whiteTexture);
+            GUI.color = originalColor;
+
+            GUILayout.Space(MeshInfoConstants.SeparatorSpacing);
         }
 
 #if NDMF_INSTALLED

--- a/Editor/MeshInfo/MeshInfoUtility.cs
+++ b/Editor/MeshInfo/MeshInfoUtility.cs
@@ -68,5 +68,29 @@ namespace Kanameliser.EditorPlus
 
             return triangleCount;
         }
+
+        public static void ProcessParticleComponents(GameObject obj, MeshInfoData data)
+        {
+            // Particle systems consume material slots on VRChat avatars (trails add a second slot),
+            // tracked separately from the mesh-based counts. Mesh particle polygons are excluded
+            // on purpose: VRChat counts them as a separate stat, not as avatar polygons
+            if (obj.GetComponent<ParticleSystem>() != null)
+            {
+                data.ParticleSystems++;
+
+                var particleRenderer = obj.GetComponent<ParticleSystemRenderer>();
+                if (particleRenderer != null && particleRenderer.sharedMaterials != null)
+                    data.ParticleMaterialSlots += particleRenderer.sharedMaterials.Length;
+            }
+
+            // Trail/Line renderers also consume material slots outside the mesh-based counts
+            var trailRenderer = obj.GetComponent<TrailRenderer>();
+            if (trailRenderer != null && trailRenderer.sharedMaterials != null)
+                data.TrailLineMaterialSlots += trailRenderer.sharedMaterials.Length;
+
+            var lineRenderer = obj.GetComponent<LineRenderer>();
+            if (lineRenderer != null && lineRenderer.sharedMaterials != null)
+                data.TrailLineMaterialSlots += lineRenderer.sharedMaterials.Length;
+        }
     }
 }

--- a/Editor/Tests/MeshInfoCalculatorTests.cs
+++ b/Editor/Tests/MeshInfoCalculatorTests.cs
@@ -1,0 +1,137 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+
+namespace Kanameliser.EditorPlus.Tests
+{
+    public class MeshInfoCalculatorTests
+    {
+        private readonly List<Object> createdObjects = new();
+        private MeshInfoCalculator calculator;
+
+        [SetUp]
+        public void SetUp()
+        {
+            calculator = new MeshInfoCalculator();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            for (int i = createdObjects.Count - 1; i >= 0; i--)
+            {
+                if (createdObjects[i] != null)
+                {
+                    Object.DestroyImmediate(createdObjects[i]);
+                }
+            }
+
+            createdObjects.Clear();
+        }
+
+        private GameObject CreateGameObject(string name, GameObject parent = null)
+        {
+            var gameObject = new GameObject(name);
+            if (parent != null)
+            {
+                gameObject.transform.SetParent(parent.transform, false);
+            }
+
+            createdObjects.Add(gameObject);
+            return gameObject;
+        }
+
+        private GameObject CreateCube(string name, GameObject parent = null)
+        {
+            var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+            cube.name = name;
+            if (parent != null)
+            {
+                cube.transform.SetParent(parent.transform, false);
+            }
+
+            createdObjects.Add(cube);
+            return cube;
+        }
+
+        [Test]
+        public void CalculateMeshInfo_CountsParticleSystemAndItsMaterialSlots()
+        {
+            var root = CreateGameObject("Root");
+            var particleObject = CreateGameObject("Particles", root);
+            particleObject.AddComponent<ParticleSystem>();
+            var particleRenderer = particleObject.GetComponent<ParticleSystemRenderer>();
+
+            var data = calculator.CalculateMeshInfo(new[] { root });
+
+            Assert.AreEqual(1, data.ParticleSystems);
+            Assert.GreaterOrEqual(data.ParticleMaterialSlots, 1);
+            Assert.AreEqual(particleRenderer.sharedMaterials.Length, data.ParticleMaterialSlots);
+            Assert.AreEqual(0, data.TrailLineMaterialSlots);
+        }
+
+        [Test]
+        public void CalculateMeshInfo_CountsNestedParticleSystems()
+        {
+            var root = CreateGameObject("Root");
+            var first = CreateGameObject("First", root);
+            first.AddComponent<ParticleSystem>();
+            var second = CreateGameObject("Second", first);
+            second.AddComponent<ParticleSystem>();
+
+            var data = calculator.CalculateMeshInfo(new[] { root });
+
+            Assert.AreEqual(2, data.ParticleSystems);
+        }
+
+        [Test]
+        public void CalculateMeshInfo_CountsTrailAndLineRendererMaterialSlots()
+        {
+            var root = CreateGameObject("Root");
+            var trailObject = CreateGameObject("Trail", root);
+            var trailRenderer = trailObject.AddComponent<TrailRenderer>();
+            var lineObject = CreateGameObject("Line", root);
+            var lineRenderer = lineObject.AddComponent<LineRenderer>();
+
+            var data = calculator.CalculateMeshInfo(new[] { root });
+
+            Assert.AreEqual(0, data.ParticleSystems);
+            Assert.AreEqual(0, data.ParticleMaterialSlots);
+            Assert.AreEqual(trailRenderer.sharedMaterials.Length + lineRenderer.sharedMaterials.Length,
+                data.TrailLineMaterialSlots);
+        }
+
+        [Test]
+        public void CalculateMeshInfo_SkipsEditorOnlyParticleSystems()
+        {
+            var root = CreateGameObject("Root");
+            var particleObject = CreateGameObject("Particles", root);
+            particleObject.tag = "EditorOnly";
+            particleObject.AddComponent<ParticleSystem>();
+
+            var data = calculator.CalculateMeshInfo(new[] { root });
+
+            Assert.AreEqual(0, data.ParticleSystems);
+            Assert.AreEqual(0, data.ParticleMaterialSlots);
+        }
+
+        [Test]
+        public void CalculateMeshInfo_KeepsMeshCountsSeparateFromParticleCounts()
+        {
+            var root = CreateGameObject("Root");
+            var cube = CreateCube("Cube", root);
+            var meshRenderer = cube.GetComponent<MeshRenderer>();
+            var particleObject = CreateGameObject("Particles", root);
+            particleObject.AddComponent<ParticleSystem>();
+
+            var data = calculator.CalculateMeshInfo(new[] { root });
+
+            // Mesh-based counts must not include particle materials or slots
+            Assert.AreEqual(12, data.Triangles);
+            Assert.AreEqual(1, data.Meshes);
+            Assert.AreEqual(meshRenderer.sharedMaterials.Length, data.MaterialSlots);
+            Assert.AreEqual(1, data.Materials);
+            Assert.AreEqual(1, data.ParticleSystems);
+        }
+    }
+}

--- a/Editor/Tests/MeshInfoCalculatorTests.cs.meta
+++ b/Editor/Tests/MeshInfoCalculatorTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: efdaedf8f74f4eaeb3691f16f943cf88
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/README.ja.md
+++ b/README.ja.md
@@ -24,6 +24,8 @@ UnityおよびVRChatのための便利なエディター拡張機能セット。
 選択したオブジェクトとその子オブジェクトのメッシュ情報をシーンビュー左上に表示します。
 ポリゴン数・マテリアル数・マテリアルスロット数・メッシュ数を確認できます。
 
+選択したオブジェクトにパーティクルシステムやTrail/Lineレンダラーが含まれる場合は、メッシュ情報の下に別セクションとしてパーティクルシステム数とこれらが消費するマテリアルスロット数を表示します。これらもVRChatのパフォーマンスランクのMaterial Slotsを消費しますが、上のメッシュ系カウントには含まれないため分けて表示します。
+
 #### NDMFプレビュー対応
 
 NDMFプレビューがアクティブな場合、AAO/TTT/Meshiaなどの最適化結果を確認しながら調整できます。
@@ -32,6 +34,7 @@ NDMFプレビューがアクティブな場合、AAO/TTT/Meshiaなどの最適�
 - NDMFプロキシメッシュを自動検出し、緑のドットでプレビュー中であることを表示
 
 表示切替: `Tools > Kanameliser Editor Plus > [Settings] > Show Mesh Info Display`
+パーティクル情報の表示切替: `Tools > Kanameliser Editor Plus > [Settings] > Show Particle Info Display`
 
 ### Toggle Objects Active
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ A set of useful editor extensions for Unity and VRChat.
 Displays mesh information for selected objects and their children in the top-left corner of the Scene view.
 You can check polygon count, material count, material slot count, and mesh count.
 
+When the selection contains particle systems or Trail/Line renderers, a separate section below the mesh counts shows the particle system count and the material slots these renderers consume. They count toward VRChat's Material Slots performance stat but are not included in the mesh-based counts above.
+
 #### NDMF Preview Support
 
 When NDMF preview is active, you can check optimization results from AAO/TTT/Meshia and adjust accordingly.
@@ -32,6 +34,7 @@ When NDMF preview is active, you can check optimization results from AAO/TTT/Mes
 - Automatically detects NDMF proxy meshes and shows a green dot to indicate preview state
 
 Toggle: `Tools > Kanameliser Editor Plus > [Settings] > Show Mesh Info Display`
+Particle info toggle: `Tools > Kanameliser Editor Plus > [Settings] > Show Particle Info Display`
 
 ### Toggle Objects Active
 

--- a/docs~/en/features/mesh-info-display.md
+++ b/docs~/en/features/mesh-info-display.md
@@ -10,6 +10,22 @@ Information shown:
 - Material count
 - Material slot count
 - Mesh count
+- Particle system count and the material slots they consume (only when the selection contains any)
+- Material slots consumed by Trail/Line renderers (only when the selection contains any)
+
+## Particle Info Section
+
+Particle systems and Trail/Line renderers consume material slots in VRChat's avatar performance rank separately from meshes (one slot per particle system, two when trails are enabled, and one per Trail/Line renderer).
+
+Note that polygons of mesh particles (Render Mode = Mesh) are not included in the polygon/mesh counts above, because VRChat tracks them as a separate stat (Mesh Particle Active Polys) rather than as part of the avatar's Polygons.
+
+When the selection contains any of them, the following lines appear below the mesh counts, separated by a divider:
+
+- `Particle Systems` — number of particle systems
+- `Particle Slots` — material slots consumed by particle systems
+- `Trail/Line Slots` — material slots consumed by Trail/Line renderers
+
+The actual Material Slots value used by the performance rank is the sum of `Material Slots` and these additional slots.
 
 ## NDMF Preview Support
 
@@ -24,4 +40,5 @@ When NDMF preview is active, you can check optimization results from AAO, TTT, M
 
 The display can be toggled on and off.
 
-`Tools > Kanameliser Editor Plus > Show Mesh Info Display`
+- Entire display: `Tools > Kanameliser Editor Plus > [Settings] > Show Mesh Info Display`
+- Particle info section: `Tools > Kanameliser Editor Plus > [Settings] > Show Particle Info Display`

--- a/docs~/features/mesh-info-display.md
+++ b/docs~/features/mesh-info-display.md
@@ -10,6 +10,22 @@
 - マテリアル数
 - マテリアルスロット数
 - メッシュ数
+- パーティクルシステム数と消費マテリアルスロット数（選択に含まれる場合のみ）
+- Trail/Line レンダラーの消費マテリアルスロット数（選択に含まれる場合のみ）
+
+## パーティクル情報の表示
+
+パーティクルシステムや Trail/Line レンダラーは、メッシュとは別枠で VRChat のパフォーマンスランクのマテリアルスロットを消費します（パーティクルシステム 1 個で 1 スロット、Trails 有効時は 2 スロット、Trail/Line レンダラーは各 1 スロット）。
+
+なお、Render Mode が Mesh のパーティクルのポリゴン数は、VRChat ではアバターの Polygons ではなく別のスタット（Mesh Particle Active Polys）として数えられるため、上のポリゴン数・メッシュ数には含めていません。
+
+選択中のオブジェクトにこれらが含まれる場合、メッシュ情報の下に区切り線付きで表示されます：
+
+- `Particle Systems` — パーティクルシステムの数
+- `Particle Slots` — パーティクルシステムが消費するマテリアルスロット数
+- `Trail/Line Slots` — Trail/Line レンダラーが消費するマテリアルスロット数
+
+パフォーマンスランクが参照する実際のマテリアルスロット数は、`Material Slots` とこれらの追加スロットの合計になります。
 
 ## NDMFプレビュー対応
 
@@ -24,4 +40,5 @@ NDMFプレビューがアクティブな場合、AAO・TTT・Meshia などの最
 
 表示のオンオフが可能です。
 
-`Tools > Kanameliser Editor Plus > Show Mesh Info Display`
+- 表示全体：`Tools > Kanameliser Editor Plus > [Settings] > Show Mesh Info Display`
+- パーティクル情報のセクション：`Tools > Kanameliser Editor Plus > [Settings] > Show Particle Info Display`


### PR DESCRIPTION
## What

シーンビューの Mesh Info に、パーティクルシステムと Trail/Line レンダラーの情報を表示する別セクションを追加します。

- 選択中のオブジェクト（子を含む）にパーティクルシステムや Trail/Line レンダラーが含まれる場合のみ、既存のメッシュ情報の下に区切り線付きで `Particle Systems` / `Particle Slots` / `Trail/Line Slots` を表示
- ウィンドウ高さは表示行数に応じて可変
- `Tools > Kanameliser Editor Plus > [Settings] > Show Particle Info Display` でセクションのオンオフを切り替え可能（デフォルトオン、EditorPrefs に保存）
- NDMF プレビュー中は既存と同じ diff 表示（`[+N]` / `[-N]`）に対応
- `MeshInfoCalculator` のテストを 5 ケース追加
- README（日英）、CHANGELOG、ドキュメントサイト（日英）を更新

## Why

パーティクルシステムや Trail/Line レンダラーは Mesh/Skinned Mesh Renderer とは別枠で VRChat のパフォーマンスランクの Material Slots を消費しますが（パーティクルシステム 1 個で 1 スロット、Trails 有効時は 2 スロット、Trail/Line レンダラーは各 1 スロット）、Mesh Info はメッシュ系レンダラーしか数えていないため、ギミック類のスロット消費が見えませんでした。

実際に「オブジェクトごとのマテリアルスロットを確認してダイエットしているが、パーティクルシステムの数は見えない」というユーザーの声があり、その対応です。

## How

- 既存の `Material Slots` にパーティクル分を合算する案は採らず、別セクション表示にしました。既存カウントの意味（メッシュのみ）を変えず、メッシュとパーティクルのダイエットを別々に追えるためです。ランク上の実際の Material Slots は `Material Slots` と追加スロットの合計になります（docs に明記）
- スロット数は `ParticleSystemRenderer` / `TrailRenderer` / `LineRenderer` の `sharedMaterials.Length` で数えるため、Trails 有効時の 2 スロットも VRChat の数え方と一致します
- Triangles / Meshes には引き続きパーティクルを含めません。Render Mode = Mesh のパーティクルのポリゴンは、VRChat では別スタット（Mesh Particle Active Polys）として数えられるためです
- NDMF プレビュー経路では、パーティクルはプロキシ化されないため proxy 分岐の外で常に元オブジェクト側でカウントします（proxy を持つ GameObject にパーティクルが同居する場合の数え漏れ防止）
- デフォルトはオンにしました。セクションが出るのは該当コンポーネントを含む選択時だけでノイズが小さく、この機能を必要とするユーザーほど設定メニューから自分でオンにはしないと考えたためです。気になる場合のオプトアウトとしてトグルを用意しています

## 動作確認

- [x] パーティクルシステムを含む選択でセクションが表示され、スロット数が VRChat SDK のパフォーマンス統計と一致すること（Trails 有効時に 2 スロット）
- [x] Trail/Line レンダラーで `Trail/Line Slots` が表示されること
- [x] 該当コンポーネントがない選択では従来と表示が変わらないこと
- [x] `Show Particle Info Display` のオンオフが即時反映され、再起動後も保持されること
- [x] NDMF プレビュー中の diff 表示と可変高さのレイアウトが崩れないこと
- [x] 追加テスト 5 件（`MeshInfoCalculatorTests`）がテストランナーで通ること
